### PR TITLE
Implement main chat thread with Responses API

### DIFF
--- a/app/demos/branches/page.tsx
+++ b/app/demos/branches/page.tsx
@@ -1,130 +1,202 @@
 "use client"
 
-import { useState } from "react"
-import { GitBranch, Send, Loader2 } from "lucide-react"
+import { useState, useRef, useEffect, useCallback } from "react"
+import { RotateCcw, MessageSquare } from "lucide-react"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { ChatMessageBubble, TypingIndicator, Composer } from "@/components/chat"
+import type { ChatMessage, MainThreadState, RespondResponse } from "@/lib/types"
+
+function generateId(): string {
+  return crypto.randomUUID()
+}
 
 export default function BranchesDemo() {
-  const [input, setInput] = useState("")
-  const [loading, setLoading] = useState(false)
-  const [response, setResponse] = useState<{
-    id: string
-    output_text: string
-  } | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  // Main thread state
+  const [state, setState] = useState<MainThreadState>({
+    messages: [],
+    lastResponseId: null,
+  })
+  const [inputValue, setInputValue] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
 
-  const handlePing = async () => {
-    if (!input.trim()) return
+  // Refs for autoscroll behavior
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const shouldAutoScroll = useRef(true)
 
-    setLoading(true)
-    setError(null)
-    setResponse(null)
+  // Track if user has scrolled away from bottom
+  const handleScroll = useCallback(() => {
+    const container = messagesContainerRef.current
+    if (!container) return
+
+    const { scrollTop, scrollHeight, clientHeight } = container
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight
+    // Consider "at bottom" if within 100px
+    shouldAutoScroll.current = distanceFromBottom < 100
+  }, [])
+
+  // Autoscroll to bottom when new messages arrive
+  useEffect(() => {
+    if (shouldAutoScroll.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    }
+  }, [state.messages, isLoading])
+
+  // Handle sending a message
+  const handleSend = async () => {
+    const userText = inputValue.trim()
+    if (!userText || isLoading) return
+
+    // Create user message
+    const userMessage: ChatMessage = {
+      localId: generateId(),
+      role: "user",
+      text: userText,
+      createdAt: Date.now(),
+    }
+
+    // Immediately append user message and clear input
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, userMessage],
+    }))
+    setInputValue("")
+    setIsLoading(true)
+    shouldAutoScroll.current = true
 
     try {
       const res = await fetch("/api/respond", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ input: input.trim() }),
+        body: JSON.stringify({
+          input: userText,
+          previous_response_id: state.lastResponseId,
+          mode: "deep",
+        }),
       })
 
       const data = await res.json()
 
       if (!res.ok) {
-        setError(data.error || "Something went wrong")
-      } else {
-        setResponse(data)
+        throw new Error(data.error || "Failed to get response")
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Network error")
+
+      const responseData = data as RespondResponse
+
+      // Create assistant message with responseId
+      const assistantMessage: ChatMessage = {
+        localId: generateId(),
+        role: "assistant",
+        text: responseData.output_text,
+        createdAt: Date.now(),
+        responseId: responseData.id,
+      }
+
+      // Append assistant message and update lastResponseId
+      setState((prev) => ({
+        messages: [...prev.messages, assistantMessage],
+        lastResponseId: responseData.id,
+      }))
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Something went wrong"
+      toast.error(errorMessage)
     } finally {
-      setLoading(false)
+      setIsLoading(false)
     }
   }
 
+  // Handle branch button click (stub for PR #3)
+  const handleBranch = (localId: string, responseId: string) => {
+    console.log("Branch requested:", { localId, responseId })
+    toast.info("Branching will be available in the next update!", {
+      description: `Response ID: ${responseId.slice(0, 20)}...`,
+    })
+  }
+
+  // Reset chat state
+  const handleReset = () => {
+    setState({
+      messages: [],
+      lastResponseId: null,
+    })
+    setInputValue("")
+    toast.success("Chat cleared")
+  }
+
+  const hasMessages = state.messages.length > 0
+
   return (
-    <div className="p-6 space-y-6">
-      <div className="space-y-2">
-        <div className="flex items-center gap-2 text-lg font-semibold">
-          <GitBranch className="h-5 w-5" />
-          Branch Overlay Demo
+    <TooltipProvider delayDuration={300}>
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-5 w-5 text-muted-foreground" />
+            <span className="font-medium">Chat</span>
+            {state.lastResponseId && (
+              <span className="text-xs text-muted-foreground font-mono bg-muted px-2 py-0.5 rounded">
+                {state.lastResponseId.slice(0, 12)}...
+              </span>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            disabled={!hasMessages && !inputValue}
+            className="gap-1.5"
+          >
+            <RotateCcw className="h-4 w-4" />
+            New chat
+          </Button>
         </div>
-        <p className="text-sm text-muted-foreground">
-          Explore conversation branches with an intuitive overlay interface.
-          Chat UI coming in the next PR.
-        </p>
-      </div>
 
-      <div className="border border-border rounded-lg p-6 bg-muted/30">
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <label className="text-sm font-medium">API Smoke Test</label>
-            <p className="text-xs text-muted-foreground">
-              Test the OpenAI Responses API connection. Enter a message and hit send.
-            </p>
-          </div>
-
-          <div className="flex gap-2">
-            <Input
-              placeholder="Enter a test message..."
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && !loading && handlePing()}
-              disabled={loading}
-              className="flex-1"
-            />
-            <Button
-              onClick={handlePing}
-              disabled={loading || !input.trim()}
-              size="icon"
-            >
-              {loading ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </Button>
-          </div>
-
-          {error && (
-            <div className="p-3 rounded-md bg-destructive/10 border border-destructive/20 text-destructive text-sm">
-              {error}
+        {/* Messages area */}
+        <div
+          ref={messagesContainerRef}
+          onScroll={handleScroll}
+          className="flex-1 overflow-y-auto"
+        >
+          {!hasMessages && !isLoading ? (
+            // Empty state
+            <div className="flex flex-col items-center justify-center h-full text-center p-8">
+              <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
+                <MessageSquare className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <h3 className="text-lg font-medium mb-2">Start a conversation</h3>
+              <p className="text-sm text-muted-foreground max-w-sm">
+                Send a message to begin chatting. Your conversation will be
+                tracked using OpenAI&apos;s Responses API with response chaining.
+              </p>
+            </div>
+          ) : (
+            // Messages list
+            <div className="p-4 space-y-4">
+              {state.messages.map((message) => (
+                <ChatMessageBubble
+                  key={message.localId}
+                  message={message}
+                  onBranch={handleBranch}
+                />
+              ))}
+              {isLoading && <TypingIndicator />}
+              <div ref={messagesEndRef} />
             </div>
           )}
+        </div>
 
-          {response && (
-            <div className="space-y-3">
-              <div className="p-4 rounded-md bg-background border border-border">
-                <p className="text-sm whitespace-pre-wrap">{response.output_text}</p>
-              </div>
-              <div className="text-xs text-muted-foreground font-mono">
-                Response ID: {response.id}
-              </div>
-            </div>
-          )}
-        </div>
+        {/* Composer */}
+        <Composer
+          value={inputValue}
+          onChange={setInputValue}
+          onSend={handleSend}
+          disabled={isLoading}
+          placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
+        />
       </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="p-4 rounded-lg border border-border bg-card">
-          <h3 className="font-medium mb-2">Features Coming</h3>
-          <ul className="text-sm text-muted-foreground space-y-1">
-            <li>- Visual branch tree overlay</li>
-            <li>- Click to explore alternate responses</li>
-            <li>- Branch comparison view</li>
-            <li>- Response regeneration</li>
-          </ul>
-        </div>
-        <div className="p-4 rounded-lg border border-border bg-card">
-          <h3 className="font-medium mb-2">Tech Stack</h3>
-          <ul className="text-sm text-muted-foreground space-y-1">
-            <li>- OpenAI Responses API</li>
-            <li>- previous_response_id chaining</li>
-            <li>- Reasoning effort control</li>
-            <li>- Response storage</li>
-          </ul>
-        </div>
-      </div>
-    </div>
+    </TooltipProvider>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -133,3 +133,43 @@ body {
     0 4px 6px -1px rgb(0 0 0 / 0.2),
     0 10px 15px -3px rgb(0 0 0 / 0.2);
 }
+
+/* Chat message animations */
+@keyframes message-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-message-in {
+  animation: message-in 0.2s ease-out forwards;
+}
+
+/* Typing indicator animation */
+@keyframes typing-dot {
+  0%, 60%, 100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-4px);
+  }
+}
+
+.animate-typing-dot {
+  animation: typing-dot 1.4s ease-in-out infinite;
+}
+
+.animation-delay-150 {
+  animation-delay: 0.15s;
+}
+
+.animation-delay-300 {
+  animation-delay: 0.3s;
+}

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { GitBranch } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import type { ChatMessage } from "@/lib/types"
+
+interface ChatMessageProps {
+  message: ChatMessage
+  onBranch?: (localId: string, responseId: string) => void
+}
+
+export function ChatMessageBubble({ message, onBranch }: ChatMessageProps) {
+  const isUser = message.role === "user"
+  const isAssistant = message.role === "assistant"
+
+  const handleBranch = () => {
+    if (isAssistant && message.responseId && onBranch) {
+      onBranch(message.localId, message.responseId)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "group flex w-full animate-message-in",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
+      <div
+        className={cn(
+          "relative max-w-[80%] rounded-2xl px-4 py-2.5",
+          isUser
+            ? "bg-primary text-primary-foreground rounded-br-md"
+            : "bg-muted text-foreground rounded-bl-md"
+        )}
+      >
+        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+          {message.text}
+        </p>
+
+        {/* Branch button for assistant messages */}
+        {isAssistant && message.responseId && (
+          <div className="absolute -right-1 top-1/2 -translate-y-1/2 translate-x-full opacity-0 group-hover:opacity-100 transition-opacity">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                  onClick={handleBranch}
+                >
+                  <GitBranch className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                <p>Branch from here</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useRef, useEffect, KeyboardEvent } from "react"
+import { Send } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+interface ComposerProps {
+  value: string
+  onChange: (value: string) => void
+  onSend: () => void
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+}
+
+export function Composer({
+  value,
+  onChange,
+  onSend,
+  disabled = false,
+  placeholder = "Type a message...",
+  className,
+}: ComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-resize textarea based on content
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = "auto"
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
+    }
+  }, [value])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter sends, Shift+Enter adds newline
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      if (value.trim() && !disabled) {
+        onSend()
+      }
+    }
+  }
+
+  const handleSend = () => {
+    if (value.trim() && !disabled) {
+      onSend()
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-end gap-2 p-4 border-t border-border bg-card/50",
+        className
+      )}
+    >
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className="min-h-[44px] max-h-[200px] resize-none bg-background"
+      />
+      <Button
+        onClick={handleSend}
+        disabled={disabled || !value.trim()}
+        size="icon"
+        className="h-[44px] w-[44px] shrink-0"
+      >
+        <Send className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -1,0 +1,3 @@
+export { ChatMessageBubble } from "./chat-message"
+export { TypingIndicator } from "./typing-indicator"
+export { Composer } from "./composer"

--- a/components/chat/typing-indicator.tsx
+++ b/components/chat/typing-indicator.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface TypingIndicatorProps {
+  className?: string
+}
+
+export function TypingIndicator({ className }: TypingIndicatorProps) {
+  return (
+    <div
+      className={cn(
+        "flex justify-start w-full animate-message-in",
+        className
+      )}
+    >
+      <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+        <div className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-typing-dot" />
+          <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-typing-dot animation-delay-150" />
+          <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-typing-dot animation-delay-300" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Chat message types for the LLM Chat Demo
+ */
+
+export interface ChatMessage {
+  /** Unique local identifier (UUID) */
+  localId: string
+  /** Message role */
+  role: "user" | "assistant" | "context"
+  /** Message text content */
+  text: string
+  /** Timestamp (Unix ms) */
+  createdAt: number
+  /** OpenAI response ID - only present for assistant messages */
+  responseId?: string
+}
+
+export interface MainThreadState {
+  /** All messages in the main thread */
+  messages: ChatMessage[]
+  /** The response ID of the last assistant message (for chaining) */
+  lastResponseId: string | null
+}
+
+/**
+ * API request/response types
+ */
+export interface RespondRequest {
+  input: string
+  previous_response_id?: string | null
+  mode?: "fast" | "deep"
+}
+
+export interface RespondResponse {
+  id: string
+  output_text: string
+}


### PR DESCRIPTION
- Add ChatMessage, TypingIndicator, and Composer components
- Define ChatMessage and MainThreadState types in lib/types.ts
- Implement full chat UI with message bubbles and autoscroll
- Chain responses via previous_response_id for conversation context
- Store responseId on each assistant message for future branching
- Add Branch button on assistant messages (stub handler for PR #3)
- Add New chat button to reset conversation state
- Include smooth message animations and typing indicator
- Support Enter to send, Shift+Enter for newline
- Show toast notifications for errors and branch requests