### PR TITLE
Implement branch overlay with real forking

### DIFF
--- a/components/chat/branch-chip.tsx
+++ b/components/chat/branch-chip.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { GitBranch, ChevronDown, Zap, Brain } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import type { BranchThread } from "@/lib/types"
+
+interface BranchChipProps {
+  branches: BranchThread[]
+  onOpenBranch: (branchId: string) => void
+}
+
+export function BranchChip({ branches, onOpenBranch }: BranchChipProps) {
+  if (branches.length === 0) return null
+
+  // Single branch: show a compact pill
+  if (branches.length === 1) {
+    const branch = branches[0]
+    return (
+      <button
+        onClick={() => onOpenBranch(branch.id)}
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full",
+          "bg-muted/80 hover:bg-muted text-xs font-medium",
+          "transition-colors cursor-pointer",
+          "border border-border/50"
+        )}
+      >
+        <GitBranch className="h-3 w-3 text-muted-foreground" />
+        <span className="max-w-[120px] truncate">{branch.title}</span>
+        <ModeIndicator mode={branch.mode} />
+      </button>
+    )
+  }
+
+  // Multiple branches: show dropdown
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full",
+            "bg-muted/80 hover:bg-muted text-xs font-medium",
+            "transition-colors cursor-pointer",
+            "border border-border/50"
+          )}
+        >
+          <GitBranch className="h-3 w-3 text-muted-foreground" />
+          <span>Branches ({branches.length})</span>
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        {branches.map((branch) => (
+          <DropdownMenuItem
+            key={branch.id}
+            onClick={() => onOpenBranch(branch.id)}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="truncate flex-1">{branch.title}</span>
+            <ModeIndicator mode={branch.mode} />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+// Small mode indicator pill
+function ModeIndicator({ mode }: { mode: "fast" | "deep" }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px]",
+        mode === "fast"
+          ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+          : "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+      )}
+    >
+      {mode === "fast" ? (
+        <Zap className="h-2.5 w-2.5" />
+      ) : (
+        <Brain className="h-2.5 w-2.5" />
+      )}
+    </span>
+  )
+}

--- a/components/chat/branch-overlay.tsx
+++ b/components/chat/branch-overlay.tsx
@@ -1,0 +1,311 @@
+"use client"
+
+import { useState, useRef, useEffect, useCallback } from "react"
+import { GitBranch, Zap, Brain, X } from "lucide-react"
+import { toast } from "sonner"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { Composer } from "./composer"
+import { TypingIndicator } from "./typing-indicator"
+import { cn } from "@/lib/utils"
+import type { BranchThread, ChatMessage, RespondResponse } from "@/lib/types"
+
+function generateId(): string {
+  return crypto.randomUUID()
+}
+
+interface BranchOverlayProps {
+  branch: BranchThread | null
+  parentMessageText: string
+  isOpen: boolean
+  onClose: () => void
+  onUpdateBranch: (updatedBranch: BranchThread) => void
+}
+
+export function BranchOverlay({
+  branch,
+  parentMessageText,
+  isOpen,
+  onClose,
+  onUpdateBranch,
+}: BranchOverlayProps) {
+  const [inputValue, setInputValue] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Refs for autoscroll behavior
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const shouldAutoScroll = useRef(true)
+
+  // Reset input when branch changes
+  useEffect(() => {
+    setInputValue("")
+    shouldAutoScroll.current = true
+  }, [branch?.id])
+
+  // Track if user has scrolled away from bottom
+  const handleScroll = useCallback(() => {
+    const container = messagesContainerRef.current
+    if (!container) return
+
+    const { scrollTop, scrollHeight, clientHeight } = container
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight
+    shouldAutoScroll.current = distanceFromBottom < 100
+  }, [])
+
+  // Autoscroll to bottom when new messages arrive
+  useEffect(() => {
+    if (shouldAutoScroll.current && branch?.messages.length) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    }
+  }, [branch?.messages, isLoading])
+
+  // Handle mode toggle
+  const handleModeChange = (mode: "fast" | "deep") => {
+    if (!branch) return
+    onUpdateBranch({
+      ...branch,
+      mode,
+      updatedAt: Date.now(),
+    })
+  }
+
+  // Handle include in main toggle
+  const handleIncludeInMainChange = (checked: boolean) => {
+    if (!branch) return
+    onUpdateBranch({
+      ...branch,
+      includeInMain: checked,
+      updatedAt: Date.now(),
+    })
+  }
+
+  // Handle sending a message in the branch
+  const handleSend = async () => {
+    if (!branch) return
+
+    const userText = inputValue.trim()
+    if (!userText || isLoading) return
+
+    // Create user message
+    const userMessage: ChatMessage = {
+      localId: generateId(),
+      role: "user",
+      text: userText,
+      createdAt: Date.now(),
+    }
+
+    // Immediately update branch with user message
+    const updatedBranchWithUser: BranchThread = {
+      ...branch,
+      messages: [...branch.messages, userMessage],
+      updatedAt: Date.now(),
+      // Update title if this is the first message
+      title:
+        branch.messages.length === 0
+          ? userText.slice(0, 30) + (userText.length > 30 ? "..." : "")
+          : branch.title,
+    }
+    onUpdateBranch(updatedBranchWithUser)
+    setInputValue("")
+    setIsLoading(true)
+    shouldAutoScroll.current = true
+
+    try {
+      // Determine previous_response_id for chaining
+      // If branch has messages, use branch's lastResponseId
+      // Otherwise, fork from parent assistant message
+      const previousResponseId =
+        branch.lastResponseId || branch.parentAssistantResponseId
+
+      const res = await fetch("/api/respond", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          input: userText,
+          previous_response_id: previousResponseId,
+          mode: branch.mode,
+        }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to get response")
+      }
+
+      const responseData = data as RespondResponse
+
+      // Create assistant message with responseId
+      const assistantMessage: ChatMessage = {
+        localId: generateId(),
+        role: "assistant",
+        text: responseData.output_text,
+        createdAt: Date.now(),
+        responseId: responseData.id,
+      }
+
+      // Update branch with assistant message and lastResponseId
+      const updatedBranchWithAssistant: BranchThread = {
+        ...updatedBranchWithUser,
+        messages: [...updatedBranchWithUser.messages, assistantMessage],
+        lastResponseId: responseData.id,
+        updatedAt: Date.now(),
+      }
+      onUpdateBranch(updatedBranchWithAssistant)
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Something went wrong"
+      toast.error(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!branch) return null
+
+  const truncatedParentText =
+    parentMessageText.length > 60
+      ? parentMessageText.slice(0, 60) + "..."
+      : parentMessageText
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-md flex flex-col p-0 gap-0"
+      >
+        {/* Header */}
+        <SheetHeader className="px-4 py-3 border-b border-border shrink-0">
+          <div className="flex items-center justify-between pr-8">
+            <div className="flex items-center gap-2">
+              <GitBranch className="h-4 w-4 text-muted-foreground" />
+              <SheetTitle className="text-base">Side thread</SheetTitle>
+            </div>
+            {/* Fast/Deep toggle */}
+            <div className="flex items-center gap-1 bg-muted rounded-full p-0.5">
+              <button
+                onClick={() => handleModeChange("fast")}
+                className={cn(
+                  "flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors",
+                  branch.mode === "fast"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Zap className="h-3 w-3" />
+                Fast
+              </button>
+              <button
+                onClick={() => handleModeChange("deep")}
+                className={cn(
+                  "flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors",
+                  branch.mode === "deep"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Brain className="h-3 w-3" />
+                Deep
+              </button>
+            </div>
+          </div>
+          <SheetDescription className="text-xs text-muted-foreground line-clamp-1 text-left">
+            Branched from: &ldquo;{truncatedParentText}&rdquo;
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Include in main toggle */}
+        <div className="px-4 py-2 border-b border-border shrink-0">
+          <div className="flex items-center justify-between">
+            <Label
+              htmlFor="include-in-main"
+              className="text-xs text-muted-foreground cursor-pointer"
+            >
+              Include branch in main chat context
+            </Label>
+            <Switch
+              id="include-in-main"
+              checked={branch.includeInMain}
+              onCheckedChange={handleIncludeInMainChange}
+            />
+          </div>
+        </div>
+
+        {/* Messages area */}
+        <div
+          ref={messagesContainerRef}
+          onScroll={handleScroll}
+          className="flex-1 overflow-y-auto"
+        >
+          {branch.messages.length === 0 && !isLoading ? (
+            // Empty state
+            <div className="flex flex-col items-center justify-center h-full text-center p-6">
+              <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-3">
+                <GitBranch className="h-5 w-5 text-muted-foreground" />
+              </div>
+              <h3 className="text-sm font-medium mb-1">Start a side thread</h3>
+              <p className="text-xs text-muted-foreground max-w-[200px]">
+                Explore alternate ideas without affecting the main conversation.
+              </p>
+            </div>
+          ) : (
+            // Messages list
+            <div className="p-4 space-y-3">
+              {branch.messages.map((message) => (
+                <BranchMessage key={message.localId} message={message} />
+              ))}
+              {isLoading && <TypingIndicator />}
+              <div ref={messagesEndRef} />
+            </div>
+          )}
+        </div>
+
+        {/* Composer */}
+        <Composer
+          value={inputValue}
+          onChange={setInputValue}
+          onSend={handleSend}
+          disabled={isLoading}
+          placeholder="Continue side thread..."
+          className="border-t"
+        />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+// Simplified message component for branch (no branch button - no nesting)
+function BranchMessage({ message }: { message: ChatMessage }) {
+  const isUser = message.role === "user"
+
+  return (
+    <div
+      className={cn(
+        "flex w-full animate-message-in",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
+      <div
+        className={cn(
+          "relative max-w-[85%] rounded-2xl px-3 py-2",
+          isUser
+            ? "bg-primary text-primary-foreground rounded-br-md"
+            : "bg-muted text-foreground rounded-bl-md"
+        )}
+      >
+        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+          {message.text}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -8,14 +8,22 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import type { ChatMessage } from "@/lib/types"
+import { BranchChip } from "./branch-chip"
+import type { ChatMessage, BranchThread } from "@/lib/types"
 
 interface ChatMessageProps {
   message: ChatMessage
   onBranch?: (localId: string, responseId: string) => void
+  branches?: BranchThread[]
+  onOpenBranch?: (branchId: string) => void
 }
 
-export function ChatMessageBubble({ message, onBranch }: ChatMessageProps) {
+export function ChatMessageBubble({
+  message,
+  onBranch,
+  branches = [],
+  onOpenBranch,
+}: ChatMessageProps) {
   const isUser = message.role === "user"
   const isAssistant = message.role === "assistant"
 
@@ -25,46 +33,61 @@ export function ChatMessageBubble({ message, onBranch }: ChatMessageProps) {
     }
   }
 
+  const handleOpenBranch = (branchId: string) => {
+    if (onOpenBranch) {
+      onOpenBranch(branchId)
+    }
+  }
+
   return (
     <div
       className={cn(
-        "group flex w-full animate-message-in",
-        isUser ? "justify-end" : "justify-start"
+        "group flex flex-col w-full animate-message-in",
+        isUser ? "items-end" : "items-start"
       )}
     >
-      <div
-        className={cn(
-          "relative max-w-[80%] rounded-2xl px-4 py-2.5",
-          isUser
-            ? "bg-primary text-primary-foreground rounded-br-md"
-            : "bg-muted text-foreground rounded-bl-md"
-        )}
-      >
-        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
-          {message.text}
-        </p>
+      <div className="flex w-full" style={{ justifyContent: isUser ? "flex-end" : "flex-start" }}>
+        <div
+          className={cn(
+            "relative max-w-[80%] rounded-2xl px-4 py-2.5",
+            isUser
+              ? "bg-primary text-primary-foreground rounded-br-md"
+              : "bg-muted text-foreground rounded-bl-md"
+          )}
+        >
+          <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+            {message.text}
+          </p>
 
-        {/* Branch button for assistant messages */}
-        {isAssistant && message.responseId && (
-          <div className="absolute -right-1 top-1/2 -translate-y-1/2 translate-x-full opacity-0 group-hover:opacity-100 transition-opacity">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                  onClick={handleBranch}
-                >
-                  <GitBranch className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <p>Branch from here</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
+          {/* Branch button for assistant messages */}
+          {isAssistant && message.responseId && (
+            <div className="absolute -right-1 top-1/2 -translate-y-1/2 translate-x-full opacity-0 group-hover:opacity-100 transition-opacity">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                    onClick={handleBranch}
+                  >
+                    <GitBranch className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <p>Branch from here</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+        </div>
       </div>
+
+      {/* Branch chips below assistant messages */}
+      {isAssistant && branches.length > 0 && (
+        <div className="mt-1.5 ml-1">
+          <BranchChip branches={branches} onOpenBranch={handleOpenBranch} />
+        </div>
+      )}
     </div>
   )
 }

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -1,3 +1,5 @@
 export { ChatMessageBubble } from "./chat-message"
 export { TypingIndicator } from "./typing-indicator"
 export { Composer } from "./composer"
+export { BranchOverlay } from "./branch-overlay"
+export { BranchChip } from "./branch-chip"

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,34 @@ export interface MainThreadState {
 }
 
 /**
+ * Branch thread model - represents a side conversation forked from an assistant message
+ */
+export interface BranchThread {
+  /** Unique identifier (UUID) */
+  id: string
+  /** The localId of the parent assistant message in main thread */
+  parentAssistantLocalId: string
+  /** The responseId of the parent assistant message (fork point) */
+  parentAssistantResponseId: string
+  /** Branch title (e.g., "Branch 1" or derived from first user message) */
+  title: string
+  /** Creation timestamp (Unix ms) */
+  createdAt: number
+  /** Last update timestamp (Unix ms) */
+  updatedAt: number
+  /** Response mode for this branch */
+  mode: "fast" | "deep"
+  /** Whether to include this branch in main chat context (UI toggle; behavior in PR #4) */
+  includeInMain: boolean
+  /** How to include in main: summary or full (advanced control for PR #4) */
+  includeMode: "summary" | "full"
+  /** Messages within this branch */
+  messages: ChatMessage[]
+  /** The response ID of the last assistant message in this branch (for chaining) */
+  lastResponseId: string | null
+}
+
+/**
  * API request/response types
  */
 export interface RespondRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1566,6 +1567,52 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
- Add BranchThread interface with mode, includeInMain, and message tracking
- Create BranchOverlay component with right-side sheet:
  - Fast/Deep mode toggle (segmented control)
  - "Include branch in main chat context" toggle
  - Chat transcript and composer
  - Parent message excerpt in header
- Create BranchChip component for collapsed branch display:
  - Single chip for 1 branch
  - Dropdown with "Branches (N)" for 2+ branches
  - Mode indicator pills (fast=amber, deep=blue)
- Update ChatMessageBubble to render branch chips below assistant messages
- Implement branch state management in main page:
  - branchesByParentLocalId map for organizing branches
  - activeBranchId for tracking open overlay
  - Separate lastResponseId pointers for context isolation
- Branch fork mechanics:
  - First request uses parent assistant's responseId
  - Subsequent requests use branch's lastResponseId
- No nested branches (branch button hidden in overlay)
- Add @radix-ui/react-label for Switch labels

Context isolation: Main chat continues from mainLastResponseId, branches fork from parentAssistantResponseId and continue independently.