### PR TITLE
Chat api parameter error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,16 @@
 OPENAI_API_KEY=
 
 # Model to use for responses
-# Examples: gpt-4o, gpt-4o-mini, o1, o1-mini, o3-mini
+# Examples: gpt-4o, gpt-4o-mini, gpt-5-nano, gpt-5-medium, o1, o1-mini, o3-mini
 OPENAI_MODEL=gpt-4o
 
 # Reasoning effort for fast mode (quick responses)
+# Only applies to reasoning models (o1, o3, gpt-5 series) - ignored for gpt-4o and older
 # Options: none, low, medium, high
 OPENAI_REASONING_FAST=low
 
 # Reasoning effort for deep mode (thorough responses)
+# Only applies to reasoning models (o1, o3, gpt-5 series) - ignored for gpt-4o and older
 # Options: none, low, medium, high
 OPENAI_REASONING_DEEP=medium
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ npm run dev
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `OPENAI_API_KEY` | Your OpenAI API key | (required) |
-| `OPENAI_MODEL` | Model to use | `gpt-4o` |
-| `OPENAI_REASONING_FAST` | Reasoning effort for fast mode | `low` |
-| `OPENAI_REASONING_DEEP` | Reasoning effort for deep mode | `medium` |
+| `OPENAI_MODEL` | Model to use (e.g., `gpt-4o`, `gpt-5-nano`, `gpt-5-medium`, `o3-mini`) | `gpt-4o` |
+| `OPENAI_REASONING_FAST` | Reasoning effort for fast mode (only for o1, o3, gpt-5 models) | `low` |
+| `OPENAI_REASONING_DEEP` | Reasoning effort for deep mode (only for o1, o3, gpt-5 models) | `medium` |
 | `OPENAI_TEXT_VERBOSITY` | Text output verbosity | `low` |
 | `OPENAI_MAX_OUTPUT_TOKENS` | Max tokens per response | `600` |
 

--- a/app/api/respond/route.ts
+++ b/app/api/respond/route.ts
@@ -58,7 +58,12 @@ export async function POST(request: NextRequest) {
       requestParams.previous_response_id = body.previous_response_id
     }
 
-    if (reasoningEffort && reasoningEffort !== "none") {
+    // Only include reasoning.effort for models that support it:
+    // - o1, o3 series (reasoning models)
+    // - gpt-5 series (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-medium, gpt-5-pro, gpt-5.1, etc.)
+    // NOT supported by: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo, etc.
+    const supportsReasoning = /^(o[13](-|$)|gpt-5)/.test(model)
+    if (supportsReasoning && reasoningEffort && reasoningEffort !== "none") {
       requestParams.reasoning = {
         effort: reasoningEffort as "low" | "medium" | "high",
       }


### PR DESCRIPTION
Fixes 400 API error by conditionally sending `reasoning.effort` only to supported OpenAI reasoning models.

---
<a href="https://cursor.com/background-agent?bcId=bc-d994c748-baef-4f0d-929c-4d66952d4152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d994c748-baef-4f0d-929c-4d66952d4152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

