### PR TITLE
feat(demo3): Add @codex trigger + in-chat Task Card mini-app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,9 @@ OPENAI_STACKS_MODEL=
 # Used when attaching past chats as context
 # Leave blank to use default (gpt-4o-mini)
 OPENAI_SUMMARY_MODEL=
+
+# Codex Task Model (Demo 3)
+# Model used for generating code changes in @codex tasks
+# Recommend a capable coding model
+# Leave blank to use default (gpt-4o-mini)
+OPENAI_CODEX_MODEL=

--- a/app/api/codex/tasks/[id]/apply/route.ts
+++ b/app/api/codex/tasks/[id]/apply/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getMockTaskRunner } from "@/lib/codex"
+
+/**
+ * Helper to get demo_uid from cookies
+ */
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+/**
+ * POST /api/codex/tasks/[id]/apply - Apply task changes to workspace
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const { id } = await params
+    const runner = getMockTaskRunner()
+
+    const workspace = await runner.applyChanges(id, demoUid)
+
+    // Get updated task
+    const task = await runner.getTask(id, demoUid)
+
+    return NextResponse.json({ task, workspace })
+  } catch (error) {
+    console.error("[POST /api/codex/tasks/[id]/apply] Error:", error)
+
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to apply changes"
+
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}

--- a/app/api/codex/tasks/[id]/pr/route.ts
+++ b/app/api/codex/tasks/[id]/pr/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getMockTaskRunner } from "@/lib/codex"
+
+/**
+ * Helper to get demo_uid from cookies
+ */
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+/**
+ * POST /api/codex/tasks/[id]/pr - Create a PR from task changes
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const { id } = await params
+    const runner = getMockTaskRunner()
+
+    const result = await runner.createPR(id, demoUid)
+
+    // Get updated task
+    const task = await runner.getTask(id, demoUid)
+
+    return NextResponse.json({ task, prUrl: result.prUrl })
+  } catch (error) {
+    console.error("[POST /api/codex/tasks/[id]/pr] Error:", error)
+
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to create PR"
+
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}

--- a/app/api/codex/tasks/[id]/route.ts
+++ b/app/api/codex/tasks/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getMockTaskRunner } from "@/lib/codex"
+
+/**
+ * Helper to get demo_uid from cookies
+ */
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+/**
+ * GET /api/codex/tasks/[id] - Get a single task with full details
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const { id } = await params
+    const runner = getMockTaskRunner()
+    const task = await runner.getTask(id, demoUid)
+
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ task })
+  } catch (error) {
+    console.error("[GET /api/codex/tasks/[id]] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to get task" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/codex/tasks/route.ts
+++ b/app/api/codex/tasks/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getMockTaskRunner, getCodexStore } from "@/lib/codex"
+
+/**
+ * Helper to get demo_uid from cookies
+ */
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+/**
+ * GET /api/codex/tasks - List all tasks for the current user
+ */
+export async function GET(request: NextRequest) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const store = getCodexStore()
+    const tasks = await store.listTasks(demoUid)
+
+    // Return metadata only (without full changes for list view)
+    const taskMetas = tasks.map((t) => ({
+      id: t.id,
+      createdAt: t.createdAt,
+      updatedAt: t.updatedAt,
+      prompt: t.prompt,
+      title: t.title,
+      status: t.status,
+      prUrl: t.prUrl,
+      error: t.error,
+    }))
+
+    return NextResponse.json({ tasks: taskMetas })
+  } catch (error) {
+    console.error("[GET /api/codex/tasks] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to list tasks" },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/codex/tasks - Create and start a new task
+ *
+ * Body: { prompt: string }
+ */
+export async function POST(request: NextRequest) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const body = (await request.json()) as { prompt?: string }
+
+    if (!body.prompt || typeof body.prompt !== "string") {
+      return NextResponse.json(
+        { error: "Missing required field: prompt" },
+        { status: 400 }
+      )
+    }
+
+    // Get current workspace
+    const store = getCodexStore()
+    const workspace = await store.getWorkspace(demoUid)
+
+    // Start the task
+    const runner = getMockTaskRunner()
+    const task = await runner.startTask({
+      prompt: body.prompt,
+      workspace,
+      demoUid,
+    })
+
+    return NextResponse.json({ task }, { status: 201 })
+  } catch (error) {
+    console.error("[POST /api/codex/tasks] Error:", error)
+
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to create task"
+
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}

--- a/app/api/codex/workspace/route.ts
+++ b/app/api/codex/workspace/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getCodexStore } from "@/lib/codex"
+
+/**
+ * Helper to get demo_uid from cookies
+ */
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+/**
+ * GET /api/codex/workspace - Get the current workspace snapshot
+ */
+export async function GET(request: NextRequest) {
+  const demoUid = getDemoUid(request)
+
+  if (!demoUid) {
+    return NextResponse.json(
+      { error: "No demo_uid cookie found" },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const store = getCodexStore()
+    const workspace = await store.getWorkspace(demoUid)
+
+    return NextResponse.json({ workspace })
+  } catch (error) {
+    console.error("[GET /api/codex/workspace] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to get workspace" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/demos/codex/page.tsx
+++ b/app/demos/codex/page.tsx
@@ -1,49 +1,477 @@
-import { Terminal, Sparkles } from "lucide-react"
+"use client"
 
-export default function CodexDemo() {
+import { useState, useRef, useEffect, useCallback } from "react"
+import {
+  RotateCcw,
+  Loader2,
+  Send,
+  Terminal,
+  FileCode,
+  FolderOpen,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { TaskCard } from "@/components/codex"
+import type { CodexTask, WorkspaceSnapshot } from "@/lib/codex/types"
+
+/**
+ * Message types for the Demo 3 chat
+ */
+type MessageType = "user" | "assistant" | "task"
+
+interface ChatMessage {
+  id: string
+  type: MessageType
+  text?: string
+  taskId?: string
+  createdAt: number
+}
+
+function generateId(): string {
+  return crypto.randomUUID()
+}
+
+/**
+ * Check if a message is a @codex command
+ */
+function isCodexCommand(text: string): boolean {
+  return text.trim().toLowerCase().startsWith("@codex ")
+}
+
+/**
+ * Extract the prompt from a @codex command
+ */
+function extractCodexPrompt(text: string): string {
+  return text.trim().slice(7).trim() // Remove "@codex "
+}
+
+export default function CodexDemoPage() {
+  // State
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [tasks, setTasks] = useState<Record<string, CodexTask>>({})
+  const [workspace, setWorkspace] = useState<WorkspaceSnapshot | null>(null)
+  const [inputValue, setInputValue] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastResponseId, setLastResponseId] = useState<string | null>(null)
+  const [showWorkspace, setShowWorkspace] = useState(false)
+
+  // Refs for autoscroll
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const shouldAutoScroll = useRef(true)
+
+  // Fetch initial workspace
+  useEffect(() => {
+    async function fetchWorkspace() {
+      try {
+        const res = await fetch("/api/codex/workspace")
+        if (res.ok) {
+          const data = await res.json()
+          setWorkspace(data.workspace)
+        }
+      } catch (error) {
+        console.error("Failed to fetch workspace:", error)
+      }
+    }
+    fetchWorkspace()
+  }, [])
+
+  // Track scroll position
+  const handleScroll = useCallback(() => {
+    const container = messagesContainerRef.current
+    if (!container) return
+    const { scrollTop, scrollHeight, clientHeight } = container
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight
+    shouldAutoScroll.current = distanceFromBottom < 100
+  }, [])
+
+  // Autoscroll to bottom
+  useEffect(() => {
+    if (shouldAutoScroll.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    }
+  }, [messages, isLoading])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = "auto"
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
+    }
+  }, [inputValue])
+
+  // Refresh a task
+  const refreshTask = async (taskId: string) => {
+    try {
+      const res = await fetch(`/api/codex/tasks/${taskId}`)
+      if (res.ok) {
+        const data = await res.json()
+        setTasks((prev) => ({ ...prev, [taskId]: data.task }))
+      }
+    } catch (error) {
+      console.error("Failed to refresh task:", error)
+    }
+  }
+
+  // Apply task changes
+  const applyTaskChanges = async (taskId: string) => {
+    const res = await fetch(`/api/codex/tasks/${taskId}/apply`, {
+      method: "POST",
+    })
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error || "Failed to apply changes")
+    }
+    const data = await res.json()
+    setTasks((prev) => ({ ...prev, [taskId]: data.task }))
+    setWorkspace(data.workspace)
+  }
+
+  // Create PR
+  const createTaskPR = async (taskId: string) => {
+    const res = await fetch(`/api/codex/tasks/${taskId}/pr`, {
+      method: "POST",
+    })
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error || "Failed to create PR")
+    }
+    const data = await res.json()
+    setTasks((prev) => ({ ...prev, [taskId]: data.task }))
+  }
+
+  // Handle sending a message
+  const handleSend = async () => {
+    const text = inputValue.trim()
+    if (!text || isLoading) return
+
+    // Add user message
+    const userMessage: ChatMessage = {
+      id: generateId(),
+      type: "user",
+      text,
+      createdAt: Date.now(),
+    }
+    setMessages((prev) => [...prev, userMessage])
+    setInputValue("")
+    setIsLoading(true)
+    shouldAutoScroll.current = true
+
+    try {
+      if (isCodexCommand(text)) {
+        // Handle @codex command
+        const prompt = extractCodexPrompt(text)
+
+        // Create task via API
+        const res = await fetch("/api/codex/tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt }),
+        })
+
+        const data = await res.json()
+
+        if (!res.ok) {
+          throw new Error(data.error || "Failed to create task")
+        }
+
+        const task = data.task as CodexTask
+
+        // Store task
+        setTasks((prev) => ({ ...prev, [task.id]: task }))
+
+        // Add task card message
+        const taskMessage: ChatMessage = {
+          id: generateId(),
+          type: "task",
+          taskId: task.id,
+          createdAt: Date.now(),
+        }
+        setMessages((prev) => [...prev, taskMessage])
+
+        // Poll for completion if still running
+        if (task.status === "running" || task.status === "queued") {
+          // The task is created synchronously and waits for completion
+          // so we just refresh once
+          await refreshTask(task.id)
+        }
+      } else {
+        // Regular chat message - send to /api/respond
+        const res = await fetch("/api/respond", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            input: text,
+            previous_response_id: lastResponseId,
+            mode: "deep",
+          }),
+        })
+
+        const data = await res.json()
+
+        if (!res.ok) {
+          throw new Error(data.error || "Failed to get response")
+        }
+
+        // Add assistant message
+        const assistantMessage: ChatMessage = {
+          id: generateId(),
+          type: "assistant",
+          text: data.output_text,
+          createdAt: Date.now(),
+        }
+        setMessages((prev) => [...prev, assistantMessage])
+        setLastResponseId(data.id)
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Something went wrong"
+      toast.error(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Handle keyboard events
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      if (inputValue.trim() && !isLoading) {
+        handleSend()
+      }
+    }
+  }
+
+  // Reset chat
+  const handleReset = () => {
+    setMessages([])
+    setTasks({})
+    setLastResponseId(null)
+    setInputValue("")
+    toast.success("Chat cleared")
+  }
+
+  const hasMessages = messages.length > 0
+
   return (
-    <div className="p-6 space-y-6">
-      <div className="space-y-2">
-        <div className="flex items-center gap-2 text-lg font-semibold">
-          <Terminal className="h-5 w-5" />
-          Codex Integration Demo
+    <TooltipProvider delayDuration={300}>
+      <div className="flex h-full">
+        {/* Main chat area */}
+        <div className="flex-1 flex flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between p-4 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Terminal className="h-5 w-5 text-primary" />
+              <span className="font-medium">Codex Demo</span>
+              {lastResponseId && (
+                <span className="text-xs text-muted-foreground font-mono bg-muted px-2 py-0.5 rounded">
+                  {lastResponseId.slice(0, 12)}...
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowWorkspace(!showWorkspace)}
+                className="gap-1.5"
+              >
+                <FolderOpen className="h-4 w-4" />
+                Workspace
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleReset}
+                disabled={!hasMessages && !inputValue}
+                className="gap-1.5"
+              >
+                <RotateCcw className="h-4 w-4" />
+                New chat
+              </Button>
+            </div>
+          </div>
+
+          {/* Messages area */}
+          <div
+            ref={messagesContainerRef}
+            onScroll={handleScroll}
+            className="flex-1 overflow-y-auto"
+          >
+            {!hasMessages && !isLoading ? (
+              // Empty state
+              <div className="flex flex-col items-center justify-center h-full text-center p-8">
+                <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
+                  <Terminal className="h-8 w-8 text-primary" />
+                </div>
+                <h3 className="text-lg font-medium mb-2">Codex Demo</h3>
+                <p className="text-sm text-muted-foreground max-w-sm mb-4">
+                  Type <code className="bg-muted px-1.5 py-0.5 rounded">@codex</code>{" "}
+                  followed by a task description to generate code changes.
+                </p>
+                <div className="text-xs text-muted-foreground/70 max-w-sm p-3 bg-muted rounded-lg">
+                  <strong>Example:</strong>{" "}
+                  <code>@codex add a health check endpoint to the API</code>
+                </div>
+              </div>
+            ) : (
+              // Messages list
+              <div className="p-4 space-y-4">
+                {messages.map((message) => {
+                  if (message.type === "task" && message.taskId) {
+                    const task = tasks[message.taskId]
+                    if (!task) return null
+                    return (
+                      <TaskCard
+                        key={message.id}
+                        task={task}
+                        workspace={workspace || undefined}
+                        onApplyChanges={() => applyTaskChanges(task.id)}
+                        onCreatePR={() => createTaskPR(task.id)}
+                        onRefresh={() => refreshTask(task.id)}
+                      />
+                    )
+                  }
+
+                  return (
+                    <MessageBubble key={message.id} message={message} />
+                  )
+                })}
+                {isLoading && (
+                  <div className="flex items-start gap-3">
+                    <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                        <span className="text-sm text-muted-foreground">
+                          Processing...
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )}
+                <div ref={messagesEndRef} />
+              </div>
+            )}
+          </div>
+
+          {/* Composer */}
+          <div className="flex items-end gap-2 p-4 border-t border-border bg-card/50">
+            <Textarea
+              ref={textareaRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Type a message or @codex to run a task..."
+              disabled={isLoading}
+              rows={1}
+              className="min-h-[44px] max-h-[200px] resize-none bg-background"
+            />
+            <Button
+              onClick={handleSend}
+              disabled={isLoading || !inputValue.trim()}
+              size="icon"
+              className="h-[44px] w-[44px] shrink-0"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
-        <p className="text-sm text-muted-foreground">
-          Code generation and execution powered by structured outputs.
+
+        {/* Workspace panel */}
+        {showWorkspace && workspace && (
+          <div className="w-80 border-l border-border flex flex-col">
+            <div className="p-4 border-b border-border">
+              <div className="flex items-center gap-2 font-medium">
+                <FolderOpen className="h-4 w-4" />
+                Workspace Files
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Demo project files
+              </p>
+            </div>
+            <ScrollArea className="flex-1">
+              <div className="p-2 space-y-1">
+                {Object.keys(workspace.files)
+                  .sort()
+                  .map((path) => (
+                    <WorkspaceFileItem
+                      key={path}
+                      path={path}
+                      content={workspace.files[path]}
+                    />
+                  ))}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+/**
+ * Message bubble component
+ */
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.type === "user"
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col w-full",
+        isUser ? "items-end" : "items-start"
+      )}
+    >
+      <div
+        className={cn(
+          "relative max-w-[80%] rounded-2xl px-4 py-2.5",
+          isUser
+            ? "bg-primary text-primary-foreground rounded-br-md"
+            : "bg-muted text-foreground rounded-bl-md"
+        )}
+      >
+        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+          {message.text}
         </p>
       </div>
+    </div>
+  )
+}
 
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="rounded-full bg-muted p-4 mb-4">
-          <Sparkles className="h-8 w-8 text-muted-foreground" />
-        </div>
-        <h2 className="text-xl font-semibold mb-2">Coming Soon</h2>
-        <p className="text-muted-foreground max-w-sm">
-          This demo will showcase code generation, syntax highlighting,
-          and safe execution sandboxing.
-        </p>
-      </div>
+/**
+ * Workspace file item component
+ */
+function WorkspaceFileItem({
+  path,
+  content,
+}: {
+  path: string
+  content: string
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="p-4 rounded-lg border border-border bg-card">
-          <h3 className="font-medium mb-2">Planned Features</h3>
-          <ul className="text-sm text-muted-foreground space-y-1">
-            <li>- Multi-language code generation</li>
-            <li>- Live preview / execution</li>
-            <li>- Diff view for code changes</li>
-            <li>- Project context awareness</li>
-          </ul>
-        </div>
-        <div className="p-4 rounded-lg border border-border bg-card">
-          <h3 className="font-medium mb-2">Safety Features</h3>
-          <ul className="text-sm text-muted-foreground space-y-1">
-            <li>- Sandboxed execution</li>
-            <li>- Resource limits</li>
-            <li>- Code review before run</li>
-            <li>- Rollback capabilities</li>
-          </ul>
-        </div>
-      </div>
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+      >
+        <FileCode className="h-3 w-3 text-muted-foreground" />
+        <span className="text-xs font-mono flex-1 truncate">{path}</span>
+      </button>
+      {isExpanded && (
+        <ScrollArea className="max-h-[200px]">
+          <pre className="p-2 text-[10px] font-mono bg-muted/30 whitespace-pre-wrap">
+            {content}
+          </pre>
+        </ScrollArea>
+      )}
     </div>
   )
 }

--- a/components/codex/index.ts
+++ b/components/codex/index.ts
@@ -1,0 +1,1 @@
+export { TaskCard } from "./task-card"

--- a/components/codex/task-card.tsx
+++ b/components/codex/task-card.tsx
@@ -1,0 +1,436 @@
+"use client"
+
+import { useState } from "react"
+import {
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Check,
+  AlertCircle,
+  ExternalLink,
+  Copy,
+  Play,
+  GitPullRequest,
+  FileCode,
+  ListOrdered,
+  ScrollText,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import type { CodexTask, WorkspaceSnapshot } from "@/lib/codex/types"
+import { TASK_STATUS_LABELS, TASK_STATUS_COLORS } from "@/lib/codex/types"
+
+interface TaskCardProps {
+  task: CodexTask
+  workspace?: WorkspaceSnapshot
+  onApplyChanges: () => Promise<void>
+  onCreatePR: () => Promise<void>
+  onRefresh: () => Promise<void>
+}
+
+type TabId = "overview" | "changes" | "logs"
+
+export function TaskCard({
+  task,
+  workspace,
+  onApplyChanges,
+  onCreatePR,
+  onRefresh,
+}: TaskCardProps) {
+  const [isExpanded, setIsExpanded] = useState(true)
+  const [activeTab, setActiveTab] = useState<TabId>("overview")
+  const [isApplying, setIsApplying] = useState(false)
+  const [isCreatingPR, setIsCreatingPR] = useState(false)
+
+  const isRunning = task.status === "running" || task.status === "queued"
+  const canApply =
+    task.status === "draft_ready" && !isApplying && !isCreatingPR
+  const canCreatePR =
+    (task.status === "applied" || task.status === "draft_ready") &&
+    !isApplying &&
+    !isCreatingPR &&
+    !task.prUrl
+  const hasError = task.status === "failed"
+
+  const handleApply = async () => {
+    setIsApplying(true)
+    try {
+      await onApplyChanges()
+      toast.success("Changes applied successfully")
+    } catch {
+      toast.error("Failed to apply changes")
+    } finally {
+      setIsApplying(false)
+    }
+  }
+
+  const handleCreatePR = async () => {
+    setIsCreatingPR(true)
+    try {
+      await onCreatePR()
+      toast.success("PR created successfully")
+    } catch {
+      toast.error("Failed to create PR")
+    } finally {
+      setIsCreatingPR(false)
+    }
+  }
+
+  const handleCopyDiff = () => {
+    if (task.diffUnified) {
+      navigator.clipboard.writeText(task.diffUnified)
+      toast.success("Diff copied to clipboard")
+    }
+  }
+
+  // Collapsed view
+  if (!isExpanded) {
+    return (
+      <div
+        className="flex items-center gap-3 px-4 py-3 bg-card border border-border rounded-xl cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() => setIsExpanded(true)}
+      >
+        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {isRunning && (
+            <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+          )}
+          {task.status === "draft_ready" && (
+            <FileCode className="h-4 w-4 text-amber-500" />
+          )}
+          {task.status === "applied" && (
+            <Check className="h-4 w-4 text-green-500" />
+          )}
+          {task.status === "pr_created" && (
+            <GitPullRequest className="h-4 w-4 text-purple-500" />
+          )}
+          {hasError && <AlertCircle className="h-4 w-4 text-red-500" />}
+          <span className="text-sm font-medium truncate">
+            Codex task • {task.title || "Processing..."}
+          </span>
+        </div>
+        <span
+          className={cn(
+            "text-[10px] px-2 py-0.5 rounded-full",
+            TASK_STATUS_COLORS[task.status]
+          )}
+        >
+          {TASK_STATUS_LABELS[task.status]}
+        </span>
+      </div>
+    )
+  }
+
+  // Expanded view
+  return (
+    <div className="bg-card border border-border rounded-xl overflow-hidden shadow-sm">
+      {/* Header */}
+      <div
+        className="flex items-center gap-3 px-4 py-3 border-b border-border cursor-pointer hover:bg-muted/30 transition-colors"
+        onClick={() => setIsExpanded(false)}
+      >
+        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {isRunning && (
+            <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+          )}
+          <span className="text-sm font-medium truncate">
+            {task.title || "Processing..."}
+          </span>
+        </div>
+        <span
+          className={cn(
+            "text-[10px] px-2 py-0.5 rounded-full",
+            TASK_STATUS_COLORS[task.status]
+          )}
+        >
+          {TASK_STATUS_LABELS[task.status]}
+        </span>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border">
+        <TabButton
+          active={activeTab === "overview"}
+          onClick={() => setActiveTab("overview")}
+          icon={<ListOrdered className="h-3 w-3" />}
+          label="Overview"
+        />
+        <TabButton
+          active={activeTab === "changes"}
+          onClick={() => setActiveTab("changes")}
+          icon={<FileCode className="h-3 w-3" />}
+          label={`Changes (${task.changes.length})`}
+        />
+        <TabButton
+          active={activeTab === "logs"}
+          onClick={() => setActiveTab("logs")}
+          icon={<ScrollText className="h-3 w-3" />}
+          label="Logs"
+        />
+      </div>
+
+      {/* Tab content */}
+      <div className="p-4">
+        {activeTab === "overview" && (
+          <div className="space-y-4">
+            {/* Prompt */}
+            <div>
+              <p className="text-[10px] uppercase text-muted-foreground mb-1">
+                Prompt
+              </p>
+              <p className="text-sm text-foreground">{task.prompt}</p>
+            </div>
+
+            {/* Plan */}
+            {task.planMarkdown && (
+              <div>
+                <p className="text-[10px] uppercase text-muted-foreground mb-1">
+                  Plan
+                </p>
+                <div className="text-sm text-foreground prose prose-sm dark:prose-invert max-w-none">
+                  <div className="whitespace-pre-wrap">{task.planMarkdown}</div>
+                </div>
+              </div>
+            )}
+
+            {/* Error */}
+            {task.error && (
+              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {task.error}
+                </p>
+              </div>
+            )}
+
+            {/* PR Link */}
+            {task.prUrl && (
+              <div className="p-3 bg-purple-500/10 border border-purple-500/20 rounded-lg">
+                <div className="flex items-center gap-2">
+                  <GitPullRequest className="h-4 w-4 text-purple-500" />
+                  <a
+                    href={task.prUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-purple-600 dark:text-purple-400 hover:underline flex items-center gap-1"
+                  >
+                    {task.prUrl}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === "changes" && (
+          <div className="space-y-3">
+            {task.changes.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {isRunning ? "Generating changes..." : "No changes"}
+              </p>
+            ) : (
+              task.changes.map((change, idx) => (
+                <FileChangeView
+                  key={idx}
+                  change={change}
+                  currentContent={workspace?.files[change.path]}
+                />
+              ))
+            )}
+          </div>
+        )}
+
+        {activeTab === "logs" && (
+          <ScrollArea className="h-[200px]">
+            <div className="space-y-1 font-mono text-xs">
+              {task.logs.map((log, idx) => (
+                <div
+                  key={idx}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <span className="text-muted-foreground/50 mr-2">
+                    [{String(idx + 1).padStart(2, "0")}]
+                  </span>
+                  {log}
+                </div>
+              ))}
+              {isRunning && (
+                <div className="flex items-center gap-2 text-blue-500">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Processing...
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+
+      {/* Actions */}
+      {!isRunning && !hasError && (
+        <div className="flex items-center gap-2 px-4 py-3 border-t border-border bg-muted/30">
+          {canApply && (
+            <Button
+              size="sm"
+              onClick={handleApply}
+              disabled={isApplying}
+              className="gap-1.5"
+            >
+              {isApplying ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Play className="h-3 w-3" />
+              )}
+              Apply Changes
+            </Button>
+          )}
+
+          {canCreatePR && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleCreatePR}
+              disabled={isCreatingPR}
+              className="gap-1.5"
+            >
+              {isCreatingPR ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <GitPullRequest className="h-3 w-3" />
+              )}
+              Create PR
+            </Button>
+          )}
+
+          {task.diffUnified && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleCopyDiff}
+              className="gap-1.5"
+            >
+              <Copy className="h-3 w-3" />
+              Copy Diff
+            </Button>
+          )}
+
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onRefresh}
+            className="ml-auto"
+          >
+            Refresh
+          </Button>
+        </div>
+      )}
+
+      {/* Running state actions */}
+      {isRunning && (
+        <div className="flex items-center gap-2 px-4 py-3 border-t border-border bg-muted/30">
+          <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+          <span className="text-sm text-muted-foreground">
+            Generating changes...
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onRefresh}
+            className="ml-auto"
+          >
+            Refresh
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Tab button component
+ */
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      className={cn(
+        "flex items-center gap-1.5 px-3 py-2 text-xs transition-colors",
+        active
+          ? "text-primary border-b-2 border-primary -mb-px"
+          : "text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}
+
+/**
+ * File change view component
+ */
+function FileChangeView({
+  change,
+  currentContent,
+}: {
+  change: { path: string; before?: string; after: string }
+  currentContent?: string
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const isNew = !change.before
+  const isModified = !!change.before && change.before !== change.after
+  const isApplied = currentContent === change.after
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <div
+        className="flex items-center gap-2 px-3 py-2 bg-muted/50 cursor-pointer hover:bg-muted transition-colors"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        )}
+        <span className="text-xs font-mono flex-1">{change.path}</span>
+        <span
+          className={cn(
+            "text-[10px] px-1.5 py-0.5 rounded",
+            isNew && "bg-green-500/20 text-green-600 dark:text-green-400",
+            isModified && "bg-amber-500/20 text-amber-600 dark:text-amber-400"
+          )}
+        >
+          {isNew ? "NEW" : "MODIFIED"}
+        </span>
+        {isApplied && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/20 text-green-600 dark:text-green-400">
+            APPLIED
+          </span>
+        )}
+      </div>
+
+      {isExpanded && (
+        <ScrollArea className="max-h-[300px]">
+          <pre className="p-3 text-xs font-mono whitespace-pre-wrap bg-muted/20">
+            {change.after}
+          </pre>
+        </ScrollArea>
+      )}
+    </div>
+  )
+}

--- a/lib/codex/CodexCloudTaskRunner.ts
+++ b/lib/codex/CodexCloudTaskRunner.ts
@@ -1,0 +1,132 @@
+/**
+ * CodexCloudTaskRunner - Production implementation stub
+ *
+ * This is a placeholder for the real Codex Cloud SDK integration.
+ * When ready, this would:
+ * 1. Authenticate with OpenAI Codex API
+ * 2. Submit tasks to Codex Cloud for execution
+ * 3. Poll for completion or use webhooks
+ * 4. Integrate with GitHub for real PR creation
+ *
+ * TODO: Implement when Codex SDK is available
+ */
+
+import type { TaskRunner, StartTaskArgs } from "./TaskRunner"
+import type { CodexTask, WorkspaceSnapshot } from "./types"
+
+/**
+ * CodexCloudTaskRunner - NOT IMPLEMENTED
+ *
+ * This stub shows where the real Codex Cloud integration would plug in.
+ * For now, use MockTaskRunner instead.
+ */
+export class CodexCloudTaskRunner implements TaskRunner {
+  /**
+   * Start a task using Codex Cloud
+   *
+   * Production implementation would:
+   * 1. Authenticate with Codex API using CODEX_API_KEY
+   * 2. Submit the prompt + workspace context to Codex Cloud
+   * 3. Return a task ID for polling
+   *
+   * @see https://platform.openai.com/docs/api-reference/codex (future)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async startTask(args: StartTaskArgs): Promise<CodexTask> {
+    // TODO: Implement Codex Cloud integration
+    //
+    // Example pseudocode:
+    // const codex = new CodexClient({ apiKey: process.env.CODEX_API_KEY });
+    // const job = await codex.tasks.create({
+    //   prompt: args.prompt,
+    //   workspaceFiles: args.workspace.files,
+    //   model: process.env.CODEX_MODEL || "codex-3",
+    // });
+    // return this.pollForCompletion(job.id);
+
+    throw new Error(
+      "CodexCloudTaskRunner not implemented. Use MockTaskRunner for demo."
+    )
+  }
+
+  /**
+   * Apply changes from Codex Cloud to the workspace
+   *
+   * Production implementation would:
+   * 1. Fetch the completed task from Codex Cloud
+   * 2. Download generated file changes
+   * 3. Apply to workspace (or real filesystem)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async applyChanges(taskId: string, demoUid: string): Promise<WorkspaceSnapshot> {
+    // TODO: Implement
+    //
+    // Example pseudocode:
+    // const codex = new CodexClient({ apiKey: process.env.CODEX_API_KEY });
+    // const task = await codex.tasks.get(taskId);
+    // for (const change of task.changes) {
+    //   await fs.writeFile(change.path, change.content);
+    // }
+    // return updatedWorkspace;
+
+    throw new Error(
+      "CodexCloudTaskRunner not implemented. Use MockTaskRunner for demo."
+    )
+  }
+
+  /**
+   * Create a PR using GitHub integration
+   *
+   * Production implementation would:
+   * 1. Use GitHub OAuth token from user
+   * 2. Create a branch with the changes
+   * 3. Open a PR via GitHub API
+   * 4. Return the real PR URL
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createPR(taskId: string, demoUid: string): Promise<{ prUrl: string }> {
+    // TODO: Implement GitHub integration
+    //
+    // Example pseudocode:
+    // const octokit = new Octokit({ auth: user.githubToken });
+    // const branch = await octokit.git.createRef({
+    //   owner, repo, ref: `refs/heads/codex-${taskId}`, sha: baseSha
+    // });
+    // for (const change of task.changes) {
+    //   await octokit.repos.createOrUpdateFileContents({...});
+    // }
+    // const pr = await octokit.pulls.create({
+    //   owner, repo, head: branch, base: 'main', title: task.title
+    // });
+    // return { prUrl: pr.html_url };
+
+    throw new Error(
+      "CodexCloudTaskRunner not implemented. Use MockTaskRunner for demo."
+    )
+  }
+
+  /**
+   * Get a task from Codex Cloud
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getTask(taskId: string, demoUid: string): Promise<CodexTask | null> {
+    // TODO: Implement
+    //
+    // Example pseudocode:
+    // const codex = new CodexClient({ apiKey: process.env.CODEX_API_KEY });
+    // return await codex.tasks.get(taskId);
+
+    throw new Error(
+      "CodexCloudTaskRunner not implemented. Use MockTaskRunner for demo."
+    )
+  }
+}
+
+/**
+ * Environment variables needed for production:
+ *
+ * CODEX_API_KEY - API key for Codex Cloud
+ * CODEX_MODEL - Model to use (e.g., "codex-3")
+ * GITHUB_CLIENT_ID - GitHub OAuth app client ID
+ * GITHUB_CLIENT_SECRET - GitHub OAuth app client secret
+ */

--- a/lib/codex/MockTaskRunner.ts
+++ b/lib/codex/MockTaskRunner.ts
@@ -1,0 +1,330 @@
+/**
+ * MockTaskRunner - Demo implementation of TaskRunner
+ *
+ * Uses OpenAI to generate realistic task outputs including:
+ * - A title for the task
+ * - A plan in markdown format
+ * - File changes
+ * - Log messages
+ */
+
+import OpenAI from "openai"
+import { z } from "zod"
+import { zodTextFormat } from "openai/helpers/zod"
+import type { TaskRunner, StartTaskArgs } from "./TaskRunner"
+import type { CodexTask, WorkspaceSnapshot, CodexFileChange } from "./types"
+import { getCodexStore } from "./store"
+
+/**
+ * Zod schema for structured output from the model
+ */
+const FileChangeSchema = z.object({
+  path: z.string().describe("File path relative to project root"),
+  after: z.string().describe("Complete new file contents"),
+})
+
+const TaskOutputSchema = z.object({
+  title: z
+    .string()
+    .describe("A short title for this task (max 60 chars)"),
+  planMarkdown: z
+    .string()
+    .describe(
+      "A step-by-step plan in markdown format explaining what changes will be made"
+    ),
+  changes: z
+    .array(FileChangeSchema)
+    .describe("Array of file changes to apply"),
+  logs: z
+    .array(z.string())
+    .describe("Log messages showing progress"),
+})
+
+type TaskOutput = z.infer<typeof TaskOutputSchema>
+
+/**
+ * Generate a unique task ID
+ */
+function generateTaskId(): string {
+  return `task_${crypto.randomUUID().slice(0, 8)}`
+}
+
+/**
+ * Build the prompt for task generation
+ */
+function buildTaskPrompt(
+  userPrompt: string,
+  workspace: WorkspaceSnapshot
+): string {
+  const fileList = Object.entries(workspace.files)
+    .map(([path, content]) => {
+      // Truncate large files
+      const truncated =
+        content.length > 500 ? content.slice(0, 500) + "\n... (truncated)" : content
+      return `### ${path}\n\`\`\`\n${truncated}\n\`\`\``
+    })
+    .join("\n\n")
+
+  return `You are a coding assistant that generates file changes based on user requests.
+
+## Current Workspace Files
+
+${fileList}
+
+## User Request
+
+${userPrompt}
+
+## Instructions
+
+1. Generate a short, descriptive title for this task
+2. Create a step-by-step plan in markdown explaining what you'll do
+3. Generate the file changes needed (provide complete new file contents for each changed file)
+4. Create log messages that would appear during execution
+
+Be concise but thorough. Only modify files that need changes.
+Return a JSON object with: title, planMarkdown, changes, logs`
+}
+
+/**
+ * Generate a unified diff from changes
+ */
+function generateUnifiedDiff(
+  changes: CodexFileChange[],
+  workspace: WorkspaceSnapshot
+): string {
+  const diffs: string[] = []
+
+  for (const change of changes) {
+    const before = workspace.files[change.path] || ""
+    const after = change.after
+
+    // Simple diff header
+    diffs.push(`--- a/${change.path}`)
+    diffs.push(`+++ b/${change.path}`)
+
+    // Show a simplified diff (in production, use a real diff library)
+    const beforeLines = before.split("\n")
+    const afterLines = after.split("\n")
+
+    if (before === "") {
+      // New file
+      diffs.push(`@@ -0,0 +1,${afterLines.length} @@`)
+      afterLines.forEach((line) => diffs.push(`+${line}`))
+    } else {
+      // Modified file - just show first few changes for demo
+      diffs.push(`@@ -1,${beforeLines.length} +1,${afterLines.length} @@`)
+      // Show first 10 lines of each for brevity
+      beforeLines.slice(0, 10).forEach((line) => diffs.push(`-${line}`))
+      afterLines.slice(0, 10).forEach((line) => diffs.push(`+${line}`))
+      if (afterLines.length > 10) {
+        diffs.push(`... (${afterLines.length - 10} more lines)`)
+      }
+    }
+
+    diffs.push("")
+  }
+
+  return diffs.join("\n")
+}
+
+/**
+ * MockTaskRunner implementation
+ */
+export class MockTaskRunner implements TaskRunner {
+  async startTask(args: StartTaskArgs): Promise<CodexTask> {
+    const { prompt, workspace, demoUid } = args
+    const store = getCodexStore()
+
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY not configured")
+    }
+
+    // Create initial task
+    const taskId = generateTaskId()
+    const now = Date.now()
+
+    const task: CodexTask = {
+      id: taskId,
+      createdAt: now,
+      updatedAt: now,
+      prompt,
+      title: "Processing...",
+      status: "running",
+      planMarkdown: "",
+      changes: [],
+      logs: ["Task started", "Analyzing workspace..."],
+      diffUnified: "",
+    }
+
+    // Save initial task
+    await store.saveTask(demoUid, task)
+
+    try {
+      // Build prompt and call OpenAI
+      const fullPrompt = buildTaskPrompt(prompt, workspace)
+      const openai = new OpenAI({ apiKey })
+      const model = process.env.OPENAI_CODEX_MODEL || "gpt-4o-mini"
+
+      console.log(`[MockTaskRunner] Starting task ${taskId} with model ${model}`)
+
+      const response = await openai.responses.parse({
+        model,
+        input: fullPrompt,
+        store: false,
+        reasoning: { effort: "none" },
+        text: {
+          format: zodTextFormat(TaskOutputSchema, "task_output"),
+        },
+      })
+
+      const parsed = response.output_parsed as TaskOutput | null
+
+      if (!parsed) {
+        throw new Error("Failed to parse task output")
+      }
+
+      // Populate changes with before content
+      const changesWithBefore: CodexFileChange[] = parsed.changes.map(
+        (change) => ({
+          path: change.path,
+          before: workspace.files[change.path],
+          after: change.after,
+        })
+      )
+
+      // Generate unified diff
+      const diffUnified = generateUnifiedDiff(changesWithBefore, workspace)
+
+      // Update task with results
+      const updatedTask: CodexTask = {
+        ...task,
+        updatedAt: Date.now(),
+        title: parsed.title,
+        status: "draft_ready",
+        planMarkdown: parsed.planMarkdown,
+        changes: changesWithBefore,
+        diffUnified,
+        logs: [
+          ...task.logs,
+          "Generating plan...",
+          ...parsed.logs,
+          "Changes ready for review",
+        ],
+      }
+
+      await store.saveTask(demoUid, updatedTask)
+      console.log(`[MockTaskRunner] Task ${taskId} completed with ${changesWithBefore.length} changes`)
+
+      return updatedTask
+    } catch (error) {
+      console.error(`[MockTaskRunner] Task ${taskId} failed:`, error)
+
+      // Update task with error
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error"
+      const failedTask: CodexTask = {
+        ...task,
+        updatedAt: Date.now(),
+        status: "failed",
+        error: errorMessage,
+        logs: [...task.logs, `Error: ${errorMessage}`],
+      }
+
+      await store.saveTask(demoUid, failedTask)
+      return failedTask
+    }
+  }
+
+  async applyChanges(taskId: string, demoUid: string): Promise<WorkspaceSnapshot> {
+    const store = getCodexStore()
+
+    const task = await store.getTask(demoUid, taskId)
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`)
+    }
+
+    if (task.status !== "draft_ready" && task.status !== "applied") {
+      throw new Error(`Cannot apply changes: task status is ${task.status}`)
+    }
+
+    // Get current workspace
+    const workspace = await store.getWorkspace(demoUid)
+
+    // Apply changes
+    const updatedFiles = { ...workspace.files }
+    for (const change of task.changes) {
+      updatedFiles[change.path] = change.after
+    }
+
+    const updatedWorkspace: WorkspaceSnapshot = {
+      files: updatedFiles,
+      updatedAt: Date.now(),
+    }
+
+    // Save updated workspace
+    await store.saveWorkspace(demoUid, updatedWorkspace)
+
+    // Update task status
+    const updatedTask: CodexTask = {
+      ...task,
+      updatedAt: Date.now(),
+      status: "applied",
+      logs: [...task.logs, "Changes applied to workspace"],
+    }
+    await store.saveTask(demoUid, updatedTask)
+
+    console.log(`[MockTaskRunner] Applied ${task.changes.length} changes for task ${taskId}`)
+
+    return updatedWorkspace
+  }
+
+  async createPR(taskId: string, demoUid: string): Promise<{ prUrl: string }> {
+    const store = getCodexStore()
+
+    const task = await store.getTask(demoUid, taskId)
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`)
+    }
+
+    if (task.status !== "applied" && task.status !== "draft_ready") {
+      throw new Error(`Cannot create PR: task status is ${task.status}`)
+    }
+
+    // Generate fake PR URL
+    const prNumber = Math.floor(Math.random() * 900) + 100
+    const prUrl = `https://github.com/demo-org/demo-repo/pull/${prNumber}`
+
+    // Update task
+    const updatedTask: CodexTask = {
+      ...task,
+      updatedAt: Date.now(),
+      status: "pr_created",
+      prUrl,
+      logs: [...task.logs, `PR created: ${prUrl}`],
+    }
+    await store.saveTask(demoUid, updatedTask)
+
+    console.log(`[MockTaskRunner] Created PR for task ${taskId}: ${prUrl}`)
+
+    return { prUrl }
+  }
+
+  async getTask(taskId: string, demoUid: string): Promise<CodexTask | null> {
+    const store = getCodexStore()
+    return store.getTask(demoUid, taskId)
+  }
+}
+
+/**
+ * Singleton instance
+ */
+let mockRunnerInstance: MockTaskRunner | null = null
+
+export function getMockTaskRunner(): MockTaskRunner {
+  if (!mockRunnerInstance) {
+    mockRunnerInstance = new MockTaskRunner()
+  }
+  return mockRunnerInstance
+}

--- a/lib/codex/TaskRunner.ts
+++ b/lib/codex/TaskRunner.ts
@@ -1,0 +1,60 @@
+/**
+ * TaskRunner Interface
+ *
+ * Defines the contract for task runners that process @codex prompts.
+ * This allows swapping between MockTaskRunner (demo) and CodexCloudTaskRunner (production).
+ */
+
+import type { CodexTask, WorkspaceSnapshot } from "./types"
+
+/**
+ * Arguments for starting a new task
+ */
+export interface StartTaskArgs {
+  /** The user's prompt (without @codex prefix) */
+  prompt: string
+  /** Current workspace state */
+  workspace: WorkspaceSnapshot
+  /** Demo user ID for storage */
+  demoUid: string
+}
+
+/**
+ * TaskRunner interface - implemented by MockTaskRunner and CodexCloudTaskRunner
+ */
+export interface TaskRunner {
+  /**
+   * Start a new task based on the user prompt
+   *
+   * @param args - Task arguments including prompt and workspace
+   * @returns The created task (initially with status "running")
+   */
+  startTask(args: StartTaskArgs): Promise<CodexTask>
+
+  /**
+   * Apply the task's generated changes to the workspace
+   *
+   * @param taskId - The task ID
+   * @param demoUid - Demo user ID
+   * @returns Updated workspace snapshot
+   */
+  applyChanges(taskId: string, demoUid: string): Promise<WorkspaceSnapshot>
+
+  /**
+   * Create a PR from the task's changes (demo: generates fake URL)
+   *
+   * @param taskId - The task ID
+   * @param demoUid - Demo user ID
+   * @returns Object with PR URL
+   */
+  createPR(taskId: string, demoUid: string): Promise<{ prUrl: string }>
+
+  /**
+   * Get a task by ID
+   *
+   * @param taskId - The task ID
+   * @param demoUid - Demo user ID
+   * @returns The task or null if not found
+   */
+  getTask(taskId: string, demoUid: string): Promise<CodexTask | null>
+}

--- a/lib/codex/index.ts
+++ b/lib/codex/index.ts
@@ -1,0 +1,6 @@
+// Codex module exports
+export * from "./types"
+export * from "./TaskRunner"
+export * from "./store"
+export { MockTaskRunner, getMockTaskRunner } from "./MockTaskRunner"
+export { CodexCloudTaskRunner } from "./CodexCloudTaskRunner"

--- a/lib/codex/store.ts
+++ b/lib/codex/store.ts
@@ -1,0 +1,191 @@
+/**
+ * Codex Store - persistence for tasks and workspace snapshots
+ *
+ * Uses the same KV + memory fallback pattern as the chat store.
+ */
+
+import { kv } from "@vercel/kv"
+import type { CodexTask, WorkspaceSnapshot } from "./types"
+import { DEFAULT_WORKSPACE_FILES } from "./types"
+
+/**
+ * Key generation helpers
+ */
+function taskKey(demoUid: string, taskId: string): string {
+  return `codex:${demoUid}:task:${taskId}`
+}
+
+function taskListKey(demoUid: string): string {
+  return `codex:${demoUid}:tasks`
+}
+
+function workspaceKey(demoUid: string): string {
+  return `codex:${demoUid}:workspace`
+}
+
+/**
+ * Check if Vercel KV is available
+ */
+function isKvAvailable(): boolean {
+  return !!(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN)
+}
+
+/**
+ * In-memory store for local development
+ */
+class MemoryCodexStore {
+  private tasks: Map<string, Map<string, CodexTask>> = new Map()
+  private workspaces: Map<string, WorkspaceSnapshot> = new Map()
+
+  private getOrCreateUserTasks(demoUid: string): Map<string, CodexTask> {
+    if (!this.tasks.has(demoUid)) {
+      this.tasks.set(demoUid, new Map())
+    }
+    return this.tasks.get(demoUid)!
+  }
+
+  async getTask(demoUid: string, taskId: string): Promise<CodexTask | null> {
+    const userTasks = this.getOrCreateUserTasks(demoUid)
+    return userTasks.get(taskId) ?? null
+  }
+
+  async saveTask(demoUid: string, task: CodexTask): Promise<void> {
+    const userTasks = this.getOrCreateUserTasks(demoUid)
+    userTasks.set(task.id, task)
+  }
+
+  async listTasks(demoUid: string): Promise<CodexTask[]> {
+    const userTasks = this.getOrCreateUserTasks(demoUid)
+    const tasks = Array.from(userTasks.values())
+    tasks.sort((a, b) => b.createdAt - a.createdAt)
+    return tasks
+  }
+
+  async getWorkspace(demoUid: string): Promise<WorkspaceSnapshot> {
+    const existing = this.workspaces.get(demoUid)
+    if (existing) return existing
+
+    // Create default workspace
+    const workspace: WorkspaceSnapshot = {
+      files: { ...DEFAULT_WORKSPACE_FILES },
+      updatedAt: Date.now(),
+    }
+    this.workspaces.set(demoUid, workspace)
+    return workspace
+  }
+
+  async saveWorkspace(
+    demoUid: string,
+    workspace: WorkspaceSnapshot
+  ): Promise<void> {
+    this.workspaces.set(demoUid, workspace)
+  }
+}
+
+/**
+ * KV-backed store
+ */
+class KVCodexStore {
+  async getTask(demoUid: string, taskId: string): Promise<CodexTask | null> {
+    try {
+      return await kv.get<CodexTask>(taskKey(demoUid, taskId))
+    } catch (error) {
+      console.error("[KVCodexStore] getTask error:", error)
+      return null
+    }
+  }
+
+  async saveTask(demoUid: string, task: CodexTask): Promise<void> {
+    try {
+      await kv.set(taskKey(demoUid, task.id), task)
+      await kv.sadd(taskListKey(demoUid), task.id)
+    } catch (error) {
+      console.error("[KVCodexStore] saveTask error:", error)
+    }
+  }
+
+  async listTasks(demoUid: string): Promise<CodexTask[]> {
+    try {
+      const taskIds = await kv.smembers(taskListKey(demoUid))
+      if (!taskIds || taskIds.length === 0) return []
+
+      const tasks: CodexTask[] = []
+      for (const id of taskIds) {
+        const task = await kv.get<CodexTask>(taskKey(demoUid, id as string))
+        if (task) tasks.push(task)
+      }
+
+      tasks.sort((a, b) => b.createdAt - a.createdAt)
+      return tasks
+    } catch (error) {
+      console.error("[KVCodexStore] listTasks error:", error)
+      return []
+    }
+  }
+
+  async getWorkspace(demoUid: string): Promise<WorkspaceSnapshot> {
+    try {
+      const existing = await kv.get<WorkspaceSnapshot>(workspaceKey(demoUid))
+      if (existing) return existing
+
+      // Create default workspace
+      const workspace: WorkspaceSnapshot = {
+        files: { ...DEFAULT_WORKSPACE_FILES },
+        updatedAt: Date.now(),
+      }
+      await kv.set(workspaceKey(demoUid), workspace)
+      return workspace
+    } catch (error) {
+      console.error("[KVCodexStore] getWorkspace error:", error)
+      return {
+        files: { ...DEFAULT_WORKSPACE_FILES },
+        updatedAt: Date.now(),
+      }
+    }
+  }
+
+  async saveWorkspace(
+    demoUid: string,
+    workspace: WorkspaceSnapshot
+  ): Promise<void> {
+    try {
+      await kv.set(workspaceKey(demoUid), workspace)
+    } catch (error) {
+      console.error("[KVCodexStore] saveWorkspace error:", error)
+    }
+  }
+}
+
+/**
+ * Singleton memory store instance
+ */
+let memoryStoreInstance: MemoryCodexStore | null = null
+
+function getMemoryStore(): MemoryCodexStore {
+  if (!memoryStoreInstance) {
+    memoryStoreInstance = new MemoryCodexStore()
+    console.log("[CodexStore] Using in-memory store")
+  }
+  return memoryStoreInstance
+}
+
+/**
+ * Codex store interface
+ */
+export interface CodexStore {
+  getTask(demoUid: string, taskId: string): Promise<CodexTask | null>
+  saveTask(demoUid: string, task: CodexTask): Promise<void>
+  listTasks(demoUid: string): Promise<CodexTask[]>
+  getWorkspace(demoUid: string): Promise<WorkspaceSnapshot>
+  saveWorkspace(demoUid: string, workspace: WorkspaceSnapshot): Promise<void>
+}
+
+/**
+ * Get the appropriate store implementation
+ */
+export function getCodexStore(): CodexStore {
+  if (isKvAvailable()) {
+    return new KVCodexStore()
+  }
+  return getMemoryStore()
+}

--- a/lib/codex/types.ts
+++ b/lib/codex/types.ts
@@ -1,0 +1,160 @@
+/**
+ * Codex Task Types for Demo 3
+ *
+ * This defines the data model for @codex tasks that appear inline in chat.
+ */
+
+/**
+ * Task status enum
+ */
+export type CodexTaskStatus =
+  | "queued"
+  | "running"
+  | "draft_ready"
+  | "applied"
+  | "pr_created"
+  | "done"
+  | "failed"
+
+/**
+ * A file change produced by the task
+ */
+export interface CodexFileChange {
+  /** File path relative to workspace root */
+  path: string
+  /** Original content (if modifying existing file) */
+  before?: string
+  /** New content */
+  after: string
+}
+
+/**
+ * A Codex task that processes a user prompt and generates code changes
+ */
+export interface CodexTask {
+  /** Unique task ID */
+  id: string
+  /** Creation timestamp (Unix ms) */
+  createdAt: number
+  /** Last update timestamp (Unix ms) */
+  updatedAt: number
+  /** The user's original prompt (without @codex prefix) */
+  prompt: string
+  /** Generated title for the task */
+  title: string
+  /** Current status */
+  status: CodexTaskStatus
+  /** Generated plan in markdown format */
+  planMarkdown: string
+  /** File changes to apply */
+  changes: CodexFileChange[]
+  /** Unified diff string (optional, for display) */
+  diffUnified?: string
+  /** Log messages from the task runner */
+  logs: string[]
+  /** PR URL if created */
+  prUrl?: string
+  /** Error message if failed */
+  error?: string
+}
+
+/**
+ * Workspace snapshot - represents the current state of demo files
+ */
+export interface WorkspaceSnapshot {
+  /** Map of file path to file contents */
+  files: Record<string, string>
+  /** Last update timestamp */
+  updatedAt: number
+}
+
+/**
+ * Task metadata without full changes (for list views)
+ */
+export type CodexTaskMeta = Omit<CodexTask, "changes" | "planMarkdown" | "logs">
+
+/**
+ * Human-readable status labels
+ */
+export const TASK_STATUS_LABELS: Record<CodexTaskStatus, string> = {
+  queued: "Queued",
+  running: "Generating...",
+  draft_ready: "Ready to Apply",
+  applied: "Applied",
+  pr_created: "PR Created",
+  done: "Done",
+  failed: "Failed",
+}
+
+/**
+ * Status colors for UI
+ */
+export const TASK_STATUS_COLORS: Record<CodexTaskStatus, string> = {
+  queued: "bg-muted text-muted-foreground",
+  running: "bg-blue-500/20 text-blue-600 dark:text-blue-400",
+  draft_ready: "bg-amber-500/20 text-amber-600 dark:text-amber-400",
+  applied: "bg-green-500/20 text-green-600 dark:text-green-400",
+  pr_created: "bg-purple-500/20 text-purple-600 dark:text-purple-400",
+  done: "bg-green-500/20 text-green-600 dark:text-green-400",
+  failed: "bg-red-500/20 text-red-600 dark:text-red-400",
+}
+
+/**
+ * Default workspace files for demo
+ */
+export const DEFAULT_WORKSPACE_FILES: Record<string, string> = {
+  "README.md": `# Demo Project
+
+This is a sample project for the Codex demo.
+
+## Getting Started
+
+\`\`\`bash
+npm install
+npm run dev
+\`\`\`
+`,
+  "package.json": `{
+  "name": "demo-project",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "ts-node src/app.ts",
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  }
+}
+`,
+  "src/app.ts": `import express from 'express';
+import { greet } from './utils';
+
+const app = express();
+const PORT = 3000;
+
+app.get('/', (req, res) => {
+  res.json({ message: greet('World') });
+});
+
+app.listen(PORT, () => {
+  console.log(\`Server running on port \${PORT}\`);
+});
+`,
+  "src/utils.ts": `/**
+ * Utility functions
+ */
+
+export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+export function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+`,
+}


### PR DESCRIPTION
Implements Demo 3 with:
- @codex command detection in chat messages
- TaskCard component with collapsible UI, tabs (Overview/Changes/Logs)
- TaskRunner interface with MockTaskRunner (OpenAI-powered) implementation
- CodexCloudTaskRunner stub for future real Codex integration
- Workspace snapshot storage with demo project files
- API routes: POST/GET tasks, apply changes, create PR
- Fake PR generation for demo purposes

Non-regressing: Demo 1 files unchanged, new components isolated.