### PR TITLE
Set conversational chat finder as default UX

### DIFF
--- a/app/demos/history/page.tsx
+++ b/app/demos/history/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useEffect, useMemo, useCallback } from "react"
+import { useState, useEffect, useMemo, useCallback, Suspense } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import {
   History,
@@ -20,6 +21,7 @@ import {
   MoreHorizontal,
   Sparkles,
   Plus,
+  Layers,
 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -36,6 +38,7 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
+import { FinderView } from "@/components/history"
 import type {
   StoredChatCategory,
   StoredChatThreadMeta,
@@ -104,14 +107,28 @@ function formatLastRefresh(timestamp: number | null): string {
   return `Last refresh: ${formatRelativeTime(timestamp)}`
 }
 
-export default function HistoryDemo() {
+type ViewMode = "finder" | "browse"
+
+/**
+ * Inner component that uses useSearchParams
+ */
+function HistoryDemoContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // URL-based state
+  const currentChatId = searchParams.get("chatId")
+  const viewModeParam = searchParams.get("view") as ViewMode | null
+
+  // View mode (Finder is default)
+  const [viewMode, setViewMode] = useState<ViewMode>(viewModeParam || "finder")
+
   // State
   const [threads, setThreads] = useState<StoredChatThreadMeta[]>([])
   const [stacksMeta, setStacksMeta] = useState<StacksMeta | null>(null)
   const [selectedCategory, setSelectedCategory] =
     useState<StoredChatCategory | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
-  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null)
   const [selectedThread, setSelectedThread] = useState<StoredChatThread | null>(
     null
   )
@@ -119,6 +136,55 @@ export default function HistoryDemo() {
   const [isLoadingThread, setIsLoadingThread] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [refreshProgress, setRefreshProgress] = useState<string | null>(null)
+
+  // Update URL when view mode changes
+  const handleViewModeChange = useCallback(
+    (mode: ViewMode) => {
+      setViewMode(mode)
+      const params = new URLSearchParams(searchParams.toString())
+      if (mode === "finder") {
+        params.delete("view") // finder is default, don't need param
+      } else {
+        params.set("view", mode)
+      }
+      // Keep chatId if present
+      router.replace(`/demos/history?${params.toString()}`)
+    },
+    [router, searchParams]
+  )
+
+  // Handle opening a chat from finder
+  const handleOpenChat = useCallback(
+    (chatId: string, useReplace: boolean) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set("chatId", chatId)
+      const url = `/demos/history?${params.toString()}`
+
+      if (useReplace) {
+        router.replace(url)
+      } else {
+        router.push(url)
+      }
+    },
+    [router, searchParams]
+  )
+
+  // Handle selecting a thread in browse mode
+  const handleSelectThread = useCallback(
+    (threadId: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set("chatId", threadId)
+      router.push(`/demos/history?${params.toString()}`)
+    },
+    [router, searchParams]
+  )
+
+  // Handle closing the transcript view
+  const handleCloseTranscript = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete("chatId")
+    router.push(`/demos/history?${params.toString()}`)
+  }, [router, searchParams])
 
   // Fetch threads and stacks meta
   const fetchData = useCallback(async () => {
@@ -155,14 +221,14 @@ export default function HistoryDemo() {
   // Fetch selected thread details
   useEffect(() => {
     async function fetchThread() {
-      if (!selectedThreadId) {
+      if (!currentChatId) {
         setSelectedThread(null)
         return
       }
 
       setIsLoadingThread(true)
       try {
-        const res = await fetch(`/api/chats/${selectedThreadId}`)
+        const res = await fetch(`/api/chats/${currentChatId}`)
         if (res.ok) {
           const data = await res.json()
           setSelectedThread(data.thread || null)
@@ -175,13 +241,13 @@ export default function HistoryDemo() {
     }
 
     fetchThread()
-  }, [selectedThreadId])
+  }, [currentChatId])
 
   // Handle refresh stacks
   const handleRefreshStacks = async () => {
     // Count recent chats
     const recentCount = threads.filter((t) => t.category === "recent").length
-    
+
     if (recentCount === 0 && threads.length === 0) {
       toast.info("No chats to organize", {
         description: "Start some conversations in Demo 1 first.",
@@ -192,8 +258,8 @@ export default function HistoryDemo() {
     setIsRefreshing(true)
     setRefreshProgress(
       recentCount > 0
-        ? `Sorting ${recentCount} recent chat${recentCount > 1 ? "s" : ""}…`
-        : "Checking for updates…"
+        ? `Sorting ${recentCount} recent chat${recentCount > 1 ? "s" : ""}...`
+        : "Checking for updates..."
     )
 
     try {
@@ -318,14 +384,14 @@ export default function HistoryDemo() {
 
   return (
     <div className="flex h-full">
-      {/* Left sidebar - Category stacks */}
+      {/* Left sidebar - Mode toggle + Category stacks */}
       <div className="w-64 border-r border-border flex flex-col">
         {/* Header */}
         <div className="p-4 border-b border-border">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-lg font-semibold">
               <History className="h-5 w-5" />
-              Smart Stacks
+              Chat History
             </div>
             <Link href="/demos/history/chat">
               <Button variant="ghost" size="icon" className="h-8 w-8">
@@ -334,386 +400,497 @@ export default function HistoryDemo() {
             </Link>
           </div>
           <p className="text-xs text-muted-foreground mt-1">
-            AI-organized conversations
+            Find or browse past conversations
           </p>
         </div>
 
-        {/* Refresh section */}
-        <div className="p-3 border-b border-border bg-muted/30">
-          <Button
-            onClick={handleRefreshStacks}
-            disabled={isRefreshing || isLoading}
-            className="w-full gap-2"
-            size="sm"
-          >
-            {isRefreshing ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span className="truncate">
-                  {refreshProgress || "Refreshing…"}
-                </span>
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-4 w-4" />
-                Refresh Stacks
-                {recentCount > 0 && (
-                  <span className="ml-1 bg-primary-foreground/20 px-1.5 py-0.5 rounded text-[10px]">
-                    {recentCount}
-                  </span>
-                )}
-              </>
-            )}
-          </Button>
-          <div className="mt-2 space-y-0.5">
-            <p className="text-[10px] text-muted-foreground text-center">
-              {formatLastRefresh(stacksMeta?.lastRefreshAt ?? null)}
-            </p>
-            <p className="text-[10px] text-muted-foreground/60 text-center">
-              Runs daily in background • Demo uses manual refresh
-            </p>
+        {/* View mode toggle */}
+        <div className="p-3 border-b border-border">
+          <div className="flex rounded-lg bg-muted p-1">
+            <button
+              onClick={() => handleViewModeChange("finder")}
+              className={cn(
+                "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+                viewMode === "finder"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Search className="h-4 w-4" />
+              Finder
+            </button>
+            <button
+              onClick={() => handleViewModeChange("browse")}
+              className={cn(
+                "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+                viewMode === "browse"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Layers className="h-4 w-4" />
+              Browse
+            </button>
           </div>
         </div>
 
-        {/* Category list */}
-        <ScrollArea className="flex-1">
-          <div className="p-2 space-y-1">
-            {/* All chats option */}
-            <button
-              onClick={() => setSelectedCategory(null)}
-              className={cn(
-                "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors",
-                selectedCategory === null
-                  ? "bg-primary/10 text-primary font-medium"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
-              )}
+        {/* Refresh section (shown in browse mode) */}
+        {viewMode === "browse" && (
+          <div className="p-3 border-b border-border bg-muted/30">
+            <Button
+              onClick={handleRefreshStacks}
+              disabled={isRefreshing || isLoading}
+              className="w-full gap-2"
+              size="sm"
             >
-              <div className="flex items-center gap-2">
-                <MessageSquare className="h-4 w-4" />
-                <span>All Chats</span>
-              </div>
-              <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                {totalCount}
-              </span>
-            </button>
-
-            {/* Separator */}
-            <div className="h-px bg-border my-2" />
-
-            {/* Category buttons */}
-            {STORED_CHAT_CATEGORIES.map((category) => {
-              const count = categoryCounts[category] || 0
-              const isSelected = selectedCategory === category
-              const isRecent = category === "recent"
-
-              return (
-                <button
-                  key={category}
-                  onClick={() => setSelectedCategory(category)}
-                  className={cn(
-                    "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors",
-                    isSelected
-                      ? "bg-primary/10 text-primary font-medium"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                    isRecent && count > 0 && !isSelected && "text-foreground"
+              {isRefreshing ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span className="truncate">
+                    {refreshProgress || "Refreshing..."}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4" />
+                  Refresh Stacks
+                  {recentCount > 0 && (
+                    <span className="ml-1 bg-primary-foreground/20 px-1.5 py-0.5 rounded text-[10px]">
+                      {recentCount}
+                    </span>
                   )}
-                >
-                  <div className="flex items-center gap-2">
-                    {CATEGORY_ICON_MAP[category]}
-                    <span>{CATEGORY_LABELS[category]}</span>
-                  </div>
-                  <span
+                </>
+              )}
+            </Button>
+            <div className="mt-2 space-y-0.5">
+              <p className="text-[10px] text-muted-foreground text-center">
+                {formatLastRefresh(stacksMeta?.lastRefreshAt ?? null)}
+              </p>
+              <p className="text-[10px] text-muted-foreground/60 text-center">
+                Runs daily in background
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Category list (shown in browse mode) */}
+        {viewMode === "browse" && (
+          <ScrollArea className="flex-1">
+            <div className="p-2 space-y-1">
+              {/* All chats option */}
+              <button
+                onClick={() => setSelectedCategory(null)}
+                className={cn(
+                  "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors",
+                  selectedCategory === null
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <MessageSquare className="h-4 w-4" />
+                  <span>All Chats</span>
+                </div>
+                <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                  {totalCount}
+                </span>
+              </button>
+
+              {/* Separator */}
+              <div className="h-px bg-border my-2" />
+
+              {/* Category buttons */}
+              {STORED_CHAT_CATEGORIES.map((category) => {
+                const count = categoryCounts[category] || 0
+                const isSelected = selectedCategory === category
+                const isRecent = category === "recent"
+
+                return (
+                  <button
+                    key={category}
+                    onClick={() => setSelectedCategory(category)}
                     className={cn(
-                      "text-xs px-1.5 py-0.5 rounded",
-                      isRecent && count > 0
-                        ? "bg-primary/20 text-primary"
-                        : "bg-muted"
+                      "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors",
+                      isSelected
+                        ? "bg-primary/10 text-primary font-medium"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                      isRecent && count > 0 && !isSelected && "text-foreground"
                     )}
                   >
-                    {count}
-                  </span>
-                </button>
-              )
-            })}
-          </div>
-        </ScrollArea>
+                    <div className="flex items-center gap-2">
+                      {CATEGORY_ICON_MAP[category]}
+                      <span>{CATEGORY_LABELS[category]}</span>
+                    </div>
+                    <span
+                      className={cn(
+                        "text-xs px-1.5 py-0.5 rounded",
+                        isRecent && count > 0
+                          ? "bg-primary/20 text-primary"
+                          : "bg-muted"
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </ScrollArea>
+        )}
+
+        {/* Finder mode sidebar content */}
+        {viewMode === "finder" && (
+          <ScrollArea className="flex-1">
+            <div className="p-4 space-y-4">
+              <div className="text-sm text-muted-foreground">
+                <p className="mb-3">
+                  Type in the main area to find a past conversation using natural language.
+                </p>
+                <div className="space-y-2 text-xs">
+                  <p className="font-medium text-foreground">Examples:</p>
+                  <p>&bull; &quot;Find my chat about React hooks&quot;</p>
+                  <p>&bull; &quot;Where did we discuss the API?&quot;</p>
+                  <p>&bull; &quot;/find travel planning&quot;</p>
+                </div>
+              </div>
+
+              <div className="h-px bg-border" />
+
+              <div className="text-xs text-muted-foreground/70">
+                <p className="font-medium text-muted-foreground mb-1">Pro tip:</p>
+                <p>
+                  Use <code className="bg-muted px-1 rounded">/find</code> for direct
+                  search without intent detection.
+                </p>
+              </div>
+
+              {/* Quick stats */}
+              <div className="h-px bg-border" />
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>Total chats</span>
+                <span className="font-medium">{totalCount}</span>
+              </div>
+              {recentCount > 0 && (
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">Uncategorized</span>
+                  <span className="font-medium text-primary">{recentCount}</span>
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+        )}
       </div>
 
       {/* Main content area */}
       <div className="flex-1 flex flex-col">
-        {/* Search bar */}
-        <div className="p-4 border-b border-border">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              type="text"
-              placeholder="Search all conversations..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9 pr-9"
-            />
-            {searchQuery && (
-              <button
-                onClick={() => setSearchQuery("")}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            )}
-          </div>
-          {searchQuery && (
-            <p className="text-xs text-muted-foreground mt-2">
-              Searching all conversations (global search)
-            </p>
-          )}
-        </div>
-
-        {/* Content split view */}
-        <div className="flex-1 flex overflow-hidden">
-          {/* Thread list */}
-          <div className="w-80 border-r border-border flex flex-col">
-            <ScrollArea className="flex-1">
-              {isLoading ? (
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
-              ) : filteredThreads.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-center px-4">
-                  <div className="rounded-full bg-muted p-3 mb-3">
-                    <MessageSquare className="h-6 w-6 text-muted-foreground" />
-                  </div>
-                  <p className="text-sm font-medium">No conversations</p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {searchQuery
-                      ? "No results match your search"
-                      : selectedCategory
-                      ? `No ${CATEGORY_LABELS[selectedCategory].toLowerCase()} chats yet`
-                      : "Start a chat in Demo 1 to see it here"}
-                  </p>
-                </div>
-              ) : (
-                <div className="p-2 space-y-1">
-                  {filteredThreads.map((thread) => (
-                    <div
-                      key={thread.id}
-                      className={cn(
-                        "relative rounded-lg transition-colors group",
-                        selectedThreadId === thread.id
-                          ? "bg-primary/10"
-                          : "hover:bg-muted"
-                      )}
-                    >
-                      <button
-                        onClick={() => setSelectedThreadId(thread.id)}
-                        className="w-full text-left px-3 py-3 pr-10"
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span
-                                className={cn(
-                                  "text-sm font-medium truncate",
-                                  selectedThreadId === thread.id
-                                    ? "text-primary"
-                                    : "text-foreground"
-                                )}
-                              >
-                                {thread.title}
-                              </span>
-                            </div>
-                            {thread.summary && (
-                              <p className="text-xs text-muted-foreground truncate mt-0.5">
-                                {thread.summary}
-                              </p>
-                            )}
-                            <div className="flex items-center gap-2 mt-1">
-                              <span className="text-[10px] text-muted-foreground/70">
-                                {formatRelativeTime(thread.updatedAt)}
-                              </span>
-                              <span className="text-[10px] px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
-                                {CATEGORY_LABELS[thread.category]}
-                              </span>
-                            </div>
-                          </div>
-                          <ChevronRight
-                            className={cn(
-                              "h-4 w-4 shrink-0 transition-colors mt-1",
-                              selectedThreadId === thread.id
-                                ? "text-primary"
-                                : "text-muted-foreground/50 group-hover:text-muted-foreground"
-                            )}
-                          />
-                        </div>
-                      </button>
-
-                      {/* More menu */}
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            className={cn(
-                              "absolute right-2 top-3 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity",
-                              "hover:bg-muted-foreground/10"
-                            )}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-48">
-                          <DropdownMenuSub>
-                            <DropdownMenuSubTrigger>
-                              <RefreshCw className="h-3 w-3 mr-2" />
-                              Move to stack
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent>
-                              {STORED_CHAT_CATEGORIES.map((category) => (
-                                <DropdownMenuItem
-                                  key={category}
-                                  onClick={() =>
-                                    handleMoveToStack(thread.id, category)
-                                  }
-                                  disabled={thread.category === category}
-                                >
-                                  {CATEGORY_ICON_SMALL[category]}
-                                  <span className="ml-2">
-                                    {CATEGORY_LABELS[category]}
-                                  </span>
-                                  {thread.category === category && (
-                                    <span className="ml-auto text-[10px] text-muted-foreground">
-                                      Current
-                                    </span>
-                                  )}
-                                </DropdownMenuItem>
-                              ))}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuSub>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            onClick={() => setSelectedThreadId(thread.id)}
-                          >
-                            <MessageSquare className="h-3 w-3 mr-2" />
-                            View transcript
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  ))}
-                </div>
+        {viewMode === "finder" ? (
+          // Finder view
+          <FinderView
+            currentChatId={currentChatId}
+            currentChat={selectedThread}
+            onOpenChat={handleOpenChat}
+            isLoadingChat={isLoadingThread}
+          />
+        ) : (
+          // Browse view (existing stacks UI)
+          <>
+            {/* Search bar */}
+            <div className="p-4 border-b border-border">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  type="text"
+                  placeholder="Search all conversations..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9 pr-9"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery("")}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+              {searchQuery && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  Searching all conversations (global search)
+                </p>
               )}
-            </ScrollArea>
-          </div>
+            </div>
 
-          {/* Transcript view */}
-          <div className="flex-1 flex flex-col bg-muted/30">
-            {selectedThreadId ? (
-              isLoadingThread ? (
-                <div className="flex-1 flex items-center justify-center">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
-              ) : selectedThread ? (
-                <>
-                  {/* Thread header */}
-                  <div className="p-4 border-b border-border bg-background">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 min-w-0">
-                        <h2 className="font-semibold truncate">
-                          {selectedThread.title}
-                        </h2>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <p className="text-xs text-muted-foreground">
-                            {formatDate(selectedThread.createdAt)} •{" "}
-                            {selectedThread.messages.length} messages
-                          </p>
-                          <span className="text-[10px] px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
-                            {CATEGORY_LABELS[selectedThread.category]}
-                          </span>
-                        </div>
-                        {selectedThread.summary && (
-                          <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                            {selectedThread.summary}
-                          </p>
-                        )}
-                      </div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setSelectedThreadId(null)}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
+            {/* Content split view */}
+            <div className="flex-1 flex overflow-hidden">
+              {/* Thread list */}
+              <div className="w-80 border-r border-border flex flex-col">
+                <ScrollArea className="flex-1">
+                  {isLoading ? (
+                    <div className="flex items-center justify-center py-12">
+                      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                     </div>
-                  </div>
-
-                  {/* Messages */}
-                  <ScrollArea className="flex-1">
-                    <div className="p-4 space-y-4">
-                      {selectedThread.messages.map((message) => (
+                  ) : filteredThreads.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-center px-4">
+                      <div className="rounded-full bg-muted p-3 mb-3">
+                        <MessageSquare className="h-6 w-6 text-muted-foreground" />
+                      </div>
+                      <p className="text-sm font-medium">No conversations</p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {searchQuery
+                          ? "No results match your search"
+                          : selectedCategory
+                          ? `No ${CATEGORY_LABELS[selectedCategory].toLowerCase()} chats yet`
+                          : "Start a chat in Demo 1 to see it here"}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="p-2 space-y-1">
+                      {filteredThreads.map((thread) => (
                         <div
-                          key={message.id}
+                          key={thread.id}
                           className={cn(
-                            "flex",
-                            message.role === "user"
-                              ? "justify-end"
-                              : "justify-start"
+                            "relative rounded-lg transition-colors group",
+                            currentChatId === thread.id
+                              ? "bg-primary/10"
+                              : "hover:bg-muted"
                           )}
                         >
-                          <div
-                            className={cn(
-                              "max-w-[80%] rounded-2xl px-4 py-3",
-                              message.role === "user"
-                                ? "bg-primary text-primary-foreground rounded-br-md"
-                                : message.role === "context"
-                                ? "bg-amber-500/10 text-foreground border border-amber-500/20 rounded-bl-md"
-                                : "bg-card text-card-foreground border border-border rounded-bl-md"
-                            )}
+                          <button
+                            onClick={() => handleSelectThread(thread.id)}
+                            className="w-full text-left px-3 py-3 pr-10"
                           >
-                            {message.role === "context" && (
-                              <div className="text-[10px] text-amber-600 dark:text-amber-400 font-medium mb-1">
-                                CONTEXT
+                            <div className="flex items-start justify-between gap-2">
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className={cn(
+                                      "text-sm font-medium truncate",
+                                      currentChatId === thread.id
+                                        ? "text-primary"
+                                        : "text-foreground"
+                                    )}
+                                  >
+                                    {thread.title}
+                                  </span>
+                                </div>
+                                {thread.summary && (
+                                  <p className="text-xs text-muted-foreground truncate mt-0.5">
+                                    {thread.summary}
+                                  </p>
+                                )}
+                                <div className="flex items-center gap-2 mt-1">
+                                  <span className="text-[10px] text-muted-foreground/70">
+                                    {formatRelativeTime(thread.updatedAt)}
+                                  </span>
+                                  <span className="text-[10px] px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
+                                    {CATEGORY_LABELS[thread.category]}
+                                  </span>
+                                </div>
                               </div>
-                            )}
-                            <p className="text-sm whitespace-pre-wrap">
-                              {message.text}
-                            </p>
-                            <p
-                              className={cn(
-                                "text-[10px] mt-1",
-                                message.role === "user"
-                                  ? "text-primary-foreground/70"
-                                  : "text-muted-foreground/70"
-                              )}
-                            >
-                              {formatRelativeTime(message.createdAt)}
-                            </p>
-                          </div>
+                              <ChevronRight
+                                className={cn(
+                                  "h-4 w-4 shrink-0 transition-colors mt-1",
+                                  currentChatId === thread.id
+                                    ? "text-primary"
+                                    : "text-muted-foreground/50 group-hover:text-muted-foreground"
+                                )}
+                              />
+                            </div>
+                          </button>
+
+                          {/* More menu */}
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className={cn(
+                                  "absolute right-2 top-3 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity",
+                                  "hover:bg-muted-foreground/10"
+                                )}
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-48">
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger>
+                                  <RefreshCw className="h-3 w-3 mr-2" />
+                                  Move to stack
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent>
+                                  {STORED_CHAT_CATEGORIES.map((category) => (
+                                    <DropdownMenuItem
+                                      key={category}
+                                      onClick={() =>
+                                        handleMoveToStack(thread.id, category)
+                                      }
+                                      disabled={thread.category === category}
+                                    >
+                                      {CATEGORY_ICON_SMALL[category]}
+                                      <span className="ml-2">
+                                        {CATEGORY_LABELS[category]}
+                                      </span>
+                                      {thread.category === category && (
+                                        <span className="ml-auto text-[10px] text-muted-foreground">
+                                          Current
+                                        </span>
+                                      )}
+                                    </DropdownMenuItem>
+                                  ))}
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => handleSelectThread(thread.id)}
+                              >
+                                <MessageSquare className="h-3 w-3 mr-2" />
+                                View transcript
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </div>
                       ))}
                     </div>
-                  </ScrollArea>
-                </>
-              ) : (
-                <div className="flex-1 flex items-center justify-center">
-                  <p className="text-muted-foreground">Thread not found</p>
-                </div>
-              )
-            ) : (
-              <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
-                <div className="rounded-full bg-muted p-4 mb-4">
-                  <MessageSquare className="h-8 w-8 text-muted-foreground" />
-                </div>
-                <h3 className="text-lg font-medium mb-2">
-                  Select a conversation
-                </h3>
-                <p className="text-sm text-muted-foreground max-w-sm">
-                  Choose a conversation from the list to view its transcript.
-                  Click &quot;Refresh Stacks&quot; to organize recent chats with
-                  AI.
-                </p>
+                  )}
+                </ScrollArea>
               </div>
-            )}
-          </div>
-        </div>
+
+              {/* Transcript view */}
+              <div className="flex-1 flex flex-col bg-muted/30">
+                {currentChatId ? (
+                  isLoadingThread ? (
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : selectedThread ? (
+                    <>
+                      {/* Thread header */}
+                      <div className="p-4 border-b border-border bg-background">
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1 min-w-0">
+                            <h2 className="font-semibold truncate">
+                              {selectedThread.title}
+                            </h2>
+                            <div className="flex items-center gap-2 mt-0.5">
+                              <p className="text-xs text-muted-foreground">
+                                {formatDate(selectedThread.createdAt)} &bull;{" "}
+                                {selectedThread.messages.length} messages
+                              </p>
+                              <span className="text-[10px] px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
+                                {CATEGORY_LABELS[selectedThread.category]}
+                              </span>
+                            </div>
+                            {selectedThread.summary && (
+                              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                                {selectedThread.summary}
+                              </p>
+                            )}
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={handleCloseTranscript}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+
+                      {/* Messages */}
+                      <ScrollArea className="flex-1">
+                        <div className="p-4 space-y-4">
+                          {selectedThread.messages.map((message) => (
+                            <div
+                              key={message.id}
+                              className={cn(
+                                "flex",
+                                message.role === "user"
+                                  ? "justify-end"
+                                  : "justify-start"
+                              )}
+                            >
+                              <div
+                                className={cn(
+                                  "max-w-[80%] rounded-2xl px-4 py-3",
+                                  message.role === "user"
+                                    ? "bg-primary text-primary-foreground rounded-br-md"
+                                    : message.role === "context"
+                                    ? "bg-amber-500/10 text-foreground border border-amber-500/20 rounded-bl-md"
+                                    : "bg-card text-card-foreground border border-border rounded-bl-md"
+                                )}
+                              >
+                                {message.role === "context" && (
+                                  <div className="text-[10px] text-amber-600 dark:text-amber-400 font-medium mb-1">
+                                    CONTEXT
+                                  </div>
+                                )}
+                                <p className="text-sm whitespace-pre-wrap">
+                                  {message.text}
+                                </p>
+                                <p
+                                  className={cn(
+                                    "text-[10px] mt-1",
+                                    message.role === "user"
+                                      ? "text-primary-foreground/70"
+                                      : "text-muted-foreground/70"
+                                  )}
+                                >
+                                  {formatRelativeTime(message.createdAt)}
+                                </p>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </ScrollArea>
+                    </>
+                  ) : (
+                    <div className="flex-1 flex items-center justify-center">
+                      <p className="text-muted-foreground">Thread not found</p>
+                    </div>
+                  )
+                ) : (
+                  <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
+                    <div className="rounded-full bg-muted p-4 mb-4">
+                      <MessageSquare className="h-8 w-8 text-muted-foreground" />
+                    </div>
+                    <h3 className="text-lg font-medium mb-2">
+                      Select a conversation
+                    </h3>
+                    <p className="text-sm text-muted-foreground max-w-sm">
+                      Choose a conversation from the list to view its transcript.
+                      Click &quot;Refresh Stacks&quot; to organize recent chats with
+                      AI.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
+  )
+}
+
+/**
+ * Demo 2: Chat History with Finder-first UX
+ *
+ * Features:
+ * - Finder view (default): Conversational retrieval using /api/chats/intent and /api/chats/find
+ * - Browse view: Existing stacks UI for browsing categorized chats
+ * - URL-based navigation: /demos/history?chatId=xxx&view=browse
+ */
+export default function HistoryDemo() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center h-full">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <HistoryDemoContent />
+    </Suspense>
   )
 }

--- a/components/history/finder-option-card.tsx
+++ b/components/history/finder-option-card.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import {
+  Clock,
+  Briefcase,
+  Code,
+  MessageCircle,
+  User,
+  Plane,
+  ShoppingCart,
+  ArrowRight,
+  Loader2,
+  CheckCircle2,
+  Circle,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { StoredChatCategory } from "@/lib/store/types"
+import { CATEGORY_LABELS } from "@/lib/store/types"
+
+// Icon mapping for categories
+const CATEGORY_ICON_MAP: Record<StoredChatCategory, React.ReactNode> = {
+  recent: <Clock className="h-3 w-3" />,
+  professional: <Briefcase className="h-3 w-3" />,
+  coding: <Code className="h-3 w-3" />,
+  short_qa: <MessageCircle className="h-3 w-3" />,
+  personal: <User className="h-3 w-3" />,
+  travel: <Plane className="h-3 w-3" />,
+  shopping: <ShoppingCart className="h-3 w-3" />,
+}
+
+/**
+ * Format a timestamp as a relative time string
+ */
+function formatRelativeTime(timestamp: number): string {
+  const now = Date.now()
+  const diff = now - timestamp
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (days > 0) return `${days}d ago`
+  if (hours > 0) return `${hours}h ago`
+  if (minutes > 0) return `${minutes}m ago`
+  return "just now"
+}
+
+/**
+ * Get confidence label and styling based on confidence score
+ */
+function getConfidenceDisplay(confidence: number): {
+  label: string
+  className: string
+  icon: React.ReactNode
+} {
+  if (confidence >= 0.85) {
+    return {
+      label: "High match",
+      className: "text-green-600 dark:text-green-400",
+      icon: <CheckCircle2 className="h-3 w-3" />,
+    }
+  }
+  if (confidence >= 0.6) {
+    return {
+      label: "Good match",
+      className: "text-blue-600 dark:text-blue-400",
+      icon: <Circle className="h-3 w-3" />,
+    }
+  }
+  return {
+    label: "Possible match",
+    className: "text-muted-foreground",
+    icon: <Circle className="h-3 w-3" />,
+  }
+}
+
+export interface FinderOption {
+  chatId: string
+  title: string
+  summary: string
+  updatedAt: number
+  confidence: number
+  why: string
+  category?: StoredChatCategory
+}
+
+interface FinderOptionCardProps {
+  option: FinderOption
+  onClick: () => void
+  isOpening?: boolean
+  disabled?: boolean
+}
+
+/**
+ * A polished card for displaying a chat finder result.
+ * Shows title, summary, confidence indicator, updated time, and Open button.
+ */
+export function FinderOptionCard({
+  option,
+  onClick,
+  isOpening = false,
+  disabled = false,
+}: FinderOptionCardProps) {
+  const confidenceDisplay = getConfidenceDisplay(option.confidence)
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled || isOpening}
+      className={cn(
+        "w-full text-left p-4 rounded-xl border transition-all duration-200",
+        "bg-card hover:bg-accent/50 border-border",
+        "focus:outline-none focus:ring-2 focus:ring-primary/20",
+        isOpening && "bg-primary/5 border-primary/30",
+        disabled && "opacity-50 cursor-not-allowed"
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          {/* Title */}
+          <h4 className="font-medium text-foreground truncate">
+            {option.title}
+          </h4>
+
+          {/* Summary (1-2 lines) */}
+          {option.summary && (
+            <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+              {option.summary}
+            </p>
+          )}
+
+          {/* Why it matches (from LLM) */}
+          {option.why && (
+            <p className="text-xs text-muted-foreground/80 italic mt-1.5 line-clamp-1">
+              &ldquo;{option.why}&rdquo;
+            </p>
+          )}
+
+          {/* Metadata row */}
+          <div className="flex items-center gap-3 mt-2">
+            {/* Confidence indicator */}
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 text-xs font-medium",
+                confidenceDisplay.className
+              )}
+            >
+              {confidenceDisplay.icon}
+              {confidenceDisplay.label}
+            </span>
+
+            {/* Category badge */}
+            {option.category && (
+              <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
+                {CATEGORY_ICON_MAP[option.category]}
+                {CATEGORY_LABELS[option.category]}
+              </span>
+            )}
+
+            {/* Updated time */}
+            <span className="text-[10px] text-muted-foreground/70">
+              {formatRelativeTime(option.updatedAt)}
+            </span>
+          </div>
+        </div>
+
+        {/* Open button / Opening state */}
+        <div
+          className={cn(
+            "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors",
+            isOpening
+              ? "bg-primary/10 text-primary"
+              : "bg-primary text-primary-foreground hover:bg-primary/90"
+          )}
+        >
+          {isOpening ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Opening...</span>
+            </>
+          ) : (
+            <>
+              <span>Open</span>
+              <ArrowRight className="h-4 w-4" />
+            </>
+          )}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/components/history/finder-view.tsx
+++ b/components/history/finder-view.tsx
@@ -1,0 +1,618 @@
+"use client"
+
+import { useState, useRef, useEffect, useCallback, KeyboardEvent } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Send, Loader2, Search, MessageSquare, Sparkles } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { FinderOptionCard, type FinderOption } from "./finder-option-card"
+import type { StoredChatThread, StoredChatCategory } from "@/lib/store/types"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IntentResponse {
+  intent: "retrieve_chat" | "normal_chat"
+  confidence: number
+  rewrittenQuery: string
+}
+
+interface FindResponse {
+  query: string
+  options: Array<{
+    chatId: string
+    title: string
+    summary: string
+    updatedAt: number
+    confidence: number
+    why: string
+  }>
+}
+
+interface EphemeralMessage {
+  id: string
+  role: "user" | "assistant"
+  text: string
+  createdAt: number
+}
+
+// For normal chat messages (persisted)
+interface Demo2Message {
+  id: string
+  role: "user" | "assistant"
+  text: string
+  createdAt: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateId(): string {
+  return crypto.randomUUID()
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const now = Date.now()
+  const diff = now - timestamp
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) return `${hours}h ago`
+  if (minutes > 0) return `${minutes}m ago`
+  if (seconds > 10) return `${seconds}s ago`
+  return "just now"
+}
+
+/**
+ * Determine if we should auto-open based on confidence.
+ * Rules:
+ * - If only one option and confidence >= 0.75, auto-open
+ * - If top.confidence >= 0.85 AND (top - second) >= 0.15, auto-open
+ */
+function shouldAutoOpen(options: FinderOption[]): boolean {
+  if (options.length === 0) return false
+  if (options.length === 1) {
+    return options[0].confidence >= 0.75
+  }
+  const top = options[0].confidence
+  const second = options[1].confidence
+  return top >= 0.85 && top - second >= 0.15
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface FinderViewProps {
+  /**
+   * Currently selected chat ID (from URL)
+   */
+  currentChatId: string | null
+  /**
+   * Current chat data (null if no chat selected or loading)
+   */
+  currentChat: StoredChatThread | null
+  /**
+   * Callback when a chat should be opened (handles both replace and push)
+   */
+  onOpenChat: (chatId: string, useReplace: boolean) => void
+  /**
+   * Whether the current chat is being loaded
+   */
+  isLoadingChat?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function FinderView({
+  currentChatId,
+  currentChat,
+  onOpenChat,
+  isLoadingChat = false,
+}: FinderViewProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // Composer state
+  const [inputValue, setInputValue] = useState("")
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Ephemeral finder state (not persisted)
+  const [finderPending, setFinderPending] = useState(false)
+  const [finderQuery, setFinderQuery] = useState<string | null>(null)
+  const [finderOptions, setFinderOptions] = useState<FinderOption[]>([])
+  const [openingChatId, setOpeningChatId] = useState<string | null>(null)
+
+  // Normal chat state (for when intent is normal_chat)
+  const [messages, setMessages] = useState<Demo2Message[]>([])
+  const [isResponding, setIsResponding] = useState(false)
+  const [lastResponseId, setLastResponseId] = useState<string | null>(null)
+
+  // Refs for autoscroll
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const shouldAutoScroll = useRef(true)
+
+  // Track if user has scrolled away from bottom
+  const handleScroll = useCallback(() => {
+    const container = messagesContainerRef.current
+    if (!container) return
+    const { scrollTop, scrollHeight, clientHeight } = container
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight
+    shouldAutoScroll.current = distanceFromBottom < 100
+  }, [])
+
+  // Autoscroll to bottom when new content arrives
+  useEffect(() => {
+    if (shouldAutoScroll.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    }
+  }, [messages, finderOptions, finderPending, isResponding])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = "auto"
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
+    }
+  }, [inputValue])
+
+  // Determine session state
+  const isEmptySession = !currentChatId || (currentChat?.messages.length === 0)
+  const isMidChat = !isEmptySession && (currentChat?.messages.length ?? 0) > 0
+
+  // Clear ephemeral state when chat changes
+  useEffect(() => {
+    setFinderQuery(null)
+    setFinderOptions([])
+    setOpeningChatId(null)
+  }, [currentChatId])
+
+  // ---------------------------------------------------------------------------
+  // Handle opening a chat
+  // ---------------------------------------------------------------------------
+  const handleOpenChat = useCallback(
+    async (chatId: string, useReplace: boolean) => {
+      setOpeningChatId(chatId)
+
+      // Wait 500ms for the transition effect
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      onOpenChat(chatId, useReplace)
+
+      // Clear ephemeral state after navigation
+      setFinderQuery(null)
+      setFinderOptions([])
+      setOpeningChatId(null)
+    },
+    [onOpenChat]
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handle sending a message
+  // ---------------------------------------------------------------------------
+  const handleSend = async () => {
+    const userText = inputValue.trim()
+    if (!userText || finderPending || isResponding) return
+
+    setInputValue("")
+    shouldAutoScroll.current = true
+
+    // Check for /find command shortcut
+    if (userText.startsWith("/find ")) {
+      const query = userText.slice(6).trim()
+      if (!query) {
+        toast.error("Please provide a search query after /find")
+        return
+      }
+      await handleFindCommand(query)
+      return
+    }
+
+    // Step 1: Call intent detection API
+    setFinderPending(true)
+
+    try {
+      const intentRes = await fetch("/api/chats/intent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: userText,
+          context: {
+            isEmptySession,
+            isMidChat,
+          },
+        }),
+      })
+
+      if (!intentRes.ok) {
+        const data = await intentRes.json()
+        throw new Error(data.error || "Failed to detect intent")
+      }
+
+      const intentData: IntentResponse = await intentRes.json()
+
+      if (intentData.intent === "retrieve_chat") {
+        // User wants to find a past chat
+        await handleRetrieveChat(userText, intentData.rewrittenQuery)
+      } else {
+        // Normal chat - proceed with regular response
+        setFinderPending(false)
+        await handleNormalChat(userText)
+      }
+    } catch (error) {
+      setFinderPending(false)
+      const errorMessage =
+        error instanceof Error ? error.message : "Something went wrong"
+      toast.error(errorMessage)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handle /find command (direct search, skip intent detection)
+  // ---------------------------------------------------------------------------
+  const handleFindCommand = async (query: string) => {
+    setFinderPending(true)
+    setFinderQuery(query)
+
+    try {
+      const findRes = await fetch("/api/chats/find", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query }),
+      })
+
+      if (!findRes.ok) {
+        const data = await findRes.json()
+        throw new Error(data.error || "Failed to find chats")
+      }
+
+      const findData: FindResponse = await findRes.json()
+
+      // Map to FinderOption format
+      const options: FinderOption[] = findData.options.map((opt) => ({
+        chatId: opt.chatId,
+        title: opt.title,
+        summary: opt.summary,
+        updatedAt: opt.updatedAt,
+        confidence: opt.confidence,
+        why: opt.why,
+      }))
+
+      setFinderOptions(options)
+      setFinderPending(false)
+
+      // Handle auto-open for empty session
+      if (isEmptySession && shouldAutoOpen(options)) {
+        await handleOpenChat(options[0].chatId, true) // router.replace
+      }
+    } catch (error) {
+      setFinderPending(false)
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to search"
+      toast.error(errorMessage)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handle retrieve_chat intent
+  // ---------------------------------------------------------------------------
+  const handleRetrieveChat = async (
+    originalQuery: string,
+    rewrittenQuery: string
+  ) => {
+    setFinderQuery(originalQuery)
+
+    try {
+      const findRes = await fetch("/api/chats/find", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: rewrittenQuery || originalQuery }),
+      })
+
+      if (!findRes.ok) {
+        const data = await findRes.json()
+        throw new Error(data.error || "Failed to find chats")
+      }
+
+      const findData: FindResponse = await findRes.json()
+
+      // Map to FinderOption format
+      const options: FinderOption[] = findData.options.map((opt) => ({
+        chatId: opt.chatId,
+        title: opt.title,
+        summary: opt.summary,
+        updatedAt: opt.updatedAt,
+        confidence: opt.confidence,
+        why: opt.why,
+      }))
+
+      setFinderOptions(options)
+      setFinderPending(false)
+
+      if (options.length === 0) {
+        toast.info("No matching chats found")
+        return
+      }
+
+      // Handle auto-open for empty session
+      if (isEmptySession && shouldAutoOpen(options)) {
+        await handleOpenChat(options[0].chatId, true) // router.replace
+      }
+      // In mid-chat, always show options (require click)
+    } catch (error) {
+      setFinderPending(false)
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to search"
+      toast.error(errorMessage)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handle normal chat (not a retrieval request)
+  // ---------------------------------------------------------------------------
+  const handleNormalChat = async (userText: string) => {
+    // Create user message for UI
+    const userMessage: Demo2Message = {
+      id: generateId(),
+      role: "user",
+      text: userText,
+      createdAt: Date.now(),
+    }
+
+    setMessages((prev) => [...prev, userMessage])
+    setIsResponding(true)
+
+    try {
+      // Send to /api/respond
+      const res = await fetch("/api/respond", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          input: userText,
+          previous_response_id: lastResponseId,
+          mode: "deep",
+        }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to get response")
+      }
+
+      // Add assistant message to UI
+      const assistantMessage: Demo2Message = {
+        id: generateId(),
+        role: "assistant",
+        text: data.output_text,
+        createdAt: Date.now(),
+      }
+
+      setMessages((prev) => [...prev, assistantMessage])
+      setLastResponseId(data.id)
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Something went wrong"
+      toast.error(errorMessage)
+    } finally {
+      setIsResponding(false)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handle option card click
+  // ---------------------------------------------------------------------------
+  const handleOptionClick = async (option: FinderOption) => {
+    // In mid-chat, use router.push so browser back returns
+    // In empty session, use router.replace (no back entry)
+    const useReplace = isEmptySession
+    await handleOpenChat(option.chatId, useReplace)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handle keyboard events
+  // ---------------------------------------------------------------------------
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter sends, Shift+Enter adds newline
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      if (inputValue.trim() && !finderPending && !isResponding) {
+        handleSend()
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Determine what to show
+  // ---------------------------------------------------------------------------
+  const hasEphemeralContent = finderQuery !== null || finderOptions.length > 0
+  const hasMessages = messages.length > 0
+  const showEmptyState = !hasEphemeralContent && !hasMessages && !finderPending && !isResponding
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="flex flex-col h-full">
+      {/* Messages/Results area */}
+      <div
+        ref={messagesContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto"
+      >
+        {showEmptyState ? (
+          // Empty state
+          <div className="flex flex-col items-center justify-center h-full text-center p-8">
+            <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
+              <Search className="h-8 w-8 text-primary" />
+            </div>
+            <h3 className="text-lg font-medium mb-2">Find a Conversation</h3>
+            <p className="text-sm text-muted-foreground max-w-sm mb-4">
+              Type naturally to find a past chat, or just start a new conversation.
+            </p>
+            <div className="text-xs text-muted-foreground/70 max-w-sm p-3 bg-muted rounded-lg space-y-2">
+              <p>
+                <strong>Examples:</strong>
+              </p>
+              <p>&quot;Find my conversation about React hooks&quot;</p>
+              <p>&quot;Where did we discuss the API design?&quot;</p>
+              <p>&quot;/find travel planning&quot; (direct search)</p>
+            </div>
+          </div>
+        ) : (
+          // Content area
+          <div className="p-4 space-y-4">
+            {/* Ephemeral finder query (user bubble) */}
+            {finderQuery && (
+              <div className="flex justify-end">
+                <div className="max-w-[80%] rounded-2xl rounded-br-md px-4 py-2.5 bg-primary text-primary-foreground">
+                  <div className="flex items-center gap-1 mb-1 text-[10px] text-primary-foreground/70">
+                    <Search className="h-3 w-3" />
+                    <span>Finding chat...</span>
+                  </div>
+                  <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                    {finderQuery}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Finder pending state */}
+            {finderPending && (
+              <div className="flex items-start">
+                <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                    <span className="text-sm text-muted-foreground">
+                      Searching...
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Finder options (assistant bubble with cards) */}
+            {!finderPending && finderOptions.length > 0 && (
+              <div className="flex items-start">
+                <div className="max-w-[90%] space-y-3">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+                    <Sparkles className="h-4 w-4" />
+                    <span>
+                      Found {finderOptions.length} matching{" "}
+                      {finderOptions.length === 1 ? "chat" : "chats"}
+                    </span>
+                  </div>
+                  {finderOptions.map((option) => (
+                    <FinderOptionCard
+                      key={option.chatId}
+                      option={option}
+                      onClick={() => handleOptionClick(option)}
+                      isOpening={openingChatId === option.chatId}
+                      disabled={openingChatId !== null}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* No results message */}
+            {!finderPending && finderQuery && finderOptions.length === 0 && (
+              <div className="flex items-start">
+                <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+                  <p className="text-sm text-muted-foreground">
+                    No matching chats found. Try a different search or start a
+                    new conversation.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Normal chat messages */}
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={cn(
+                  "flex",
+                  message.role === "user" ? "justify-end" : "justify-start"
+                )}
+              >
+                <div
+                  className={cn(
+                    "max-w-[80%] rounded-2xl px-4 py-2.5",
+                    message.role === "user"
+                      ? "bg-primary text-primary-foreground rounded-br-md"
+                      : "bg-muted text-foreground rounded-bl-md"
+                  )}
+                >
+                  <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                    {message.text}
+                  </p>
+                  <p
+                    className={cn(
+                      "text-[10px] mt-1",
+                      message.role === "user"
+                        ? "text-primary-foreground/60"
+                        : "text-muted-foreground/60"
+                    )}
+                  >
+                    {formatRelativeTime(message.createdAt)}
+                  </p>
+                </div>
+              </div>
+            ))}
+
+            {/* Responding state */}
+            {isResponding && (
+              <div className="flex items-start">
+                <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                    <span className="text-sm text-muted-foreground">
+                      Thinking...
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-border bg-card/50">
+        <div className="flex items-end gap-2 p-4">
+          <Textarea
+            ref={textareaRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Find a chat or start a conversation..."
+            disabled={finderPending || isResponding}
+            rows={1}
+            className="min-h-[44px] max-h-[200px] resize-none bg-background"
+          />
+          <Button
+            onClick={handleSend}
+            disabled={finderPending || isResponding || !inputValue.trim()}
+            size="icon"
+            className="h-[44px] w-[44px] shrink-0"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/history/index.ts
+++ b/components/history/index.ts
@@ -1,3 +1,6 @@
 export { HistoryComposer } from "./history-composer"
 export { PastChatPickerModal } from "./past-chat-picker-modal"
 export type { AttachedChat } from "./past-chat-picker-modal"
+export { FinderOptionCard } from "./finder-option-card"
+export type { FinderOption } from "./finder-option-card"
+export { FinderView } from "./finder-view"


### PR DESCRIPTION
…eval

Add a new "Finder" view as the default Demo 2 experience:

- Add FinderOptionCard component for polished search result display with confidence indicators, summaries, and 0.5s opening transition
- Add FinderView component with ephemeral state management for conversational retrieval using /api/chats/intent and /api/chats/find
- Implement Finder/Browse toggle in sidebar (Finder is default)
- Add URL-based chat navigation with ?chatId= query parameter
- Support /find command for direct search without intent detection

Key UX behaviors implemented:
- Empty session: auto-opens high-confidence single match (router.replace)
- Mid-chat: always shows clickable cards, click uses router.push so browser back returns to original chat
- Finder UI is ephemeral and not persisted to chat history

Demo 1 non-regression verified - no protected files modified.