### PR TITLE
Fix OpenAI param mismatches: shared request builder + gpt-5-nano low …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,51 @@
+# =============================================================================
 # OpenAI Configuration
+# =============================================================================
 # Get your API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
-# Model to use for responses
-# Examples: gpt-4o, gpt-4o-mini, gpt-5-nano, gpt-5-medium, o1, o1-mini, o3-mini
-OPENAI_MODEL=gpt-4o
+# =============================================================================
+# Model Configuration (per request type)
+# =============================================================================
+# Each request type uses a specific model with appropriate reasoning settings.
+# All models below default to GPT-5 series with proper reasoning support.
 
-# Reasoning effort for fast mode (quick responses)
-# Only applies to reasoning models (o1, o3, gpt-5 series) - ignored for gpt-4o and older
-# Options: none, low, medium, high
-OPENAI_REASONING_FAST=low
+# Fast chat responses (quick answers, branch "fast" mode)
+# Default: gpt-5-nano | Reasoning: low | Verbosity: low
+OPENAI_MODEL_FAST=gpt-5-nano
 
-# Reasoning effort for deep mode (thorough responses)
-# Only applies to reasoning models (o1, o3, gpt-5 series) - ignored for gpt-4o and older
-# Options: none, low, medium, high
-OPENAI_REASONING_DEEP=medium
+# Deep chat responses (thorough answers, main chat mode)
+# Default: gpt-5-mini | Reasoning: medium | Verbosity: low
+OPENAI_MODEL_DEEP=gpt-5-mini
 
-# Text output verbosity - controls response length naturally without cutting off mid-sentence
-# This is the primary way to control response length (not max_output_tokens)
-# Options: low (concise), medium (balanced), high (detailed)
-OPENAI_TEXT_VERBOSITY=low
+# Summarization tasks (branch merging, on-demand summaries)
+# Default: gpt-5-nano | Reasoning: low | Verbosity: low
+OPENAI_MODEL_SUMMARIZE=gpt-5-nano
 
-# Maximum output tokens - OPTIONAL, only use as a cost safety limit
-# Leave unset to let responses complete naturally (recommended)
-# Only set this if you need to limit API costs; it may cause truncation
-# OPENAI_MAX_OUTPUT_TOKENS=16384
+# Intent classification (detecting chat-retrieval requests)
+# Default: gpt-5-nano | Reasoning: low | Verbosity: low
+OPENAI_MODEL_INTENT=gpt-5-nano
+
+# Smart Stacks categorization
+# Default: gpt-5-nano | Reasoning: low | Verbosity: low
+OPENAI_MODEL_STACKS=gpt-5-nano
+
+# Chat finder/reranking
+# Default: gpt-5-mini | Reasoning: low | Verbosity: low
+OPENAI_MODEL_FINDER=gpt-5-mini
+
+# Codex tasks (code generation)
+# Default: gpt-5.1-codex-mini | Reasoning: medium | Verbosity: medium
+OPENAI_MODEL_CODEX=gpt-5.1-codex-mini
+
+# =============================================================================
+# Chat Finder Configuration
+# =============================================================================
+# Maximum candidates for lexical pre-filtering (default: 30, max: 60)
+OPENAI_CHAT_FINDER_MAX_CANDIDATES=
+
+# Top K results to return from reranking (default: 5)
+OPENAI_CHAT_FINDER_TOPK=
 
 # =============================================================================
 # Vercel KV Configuration (REQUIRED for production)
@@ -46,38 +67,18 @@ OPENAI_TEXT_VERBOSITY=low
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
 
-# Smart Stacks Configuration (Demo 2)
-# Model used for categorizing and summarizing chats in Smart Stacks
-# Recommend a fast, cheap model for this task
-# Leave blank to use default (gpt-4o-mini)
-OPENAI_STACKS_MODEL=
-
-# On-demand Summary Model (Demo 2B)
-# Model used for generating chat summaries on-demand
-# Used when attaching past chats as context
-# Leave blank to use default (gpt-4o-mini)
-OPENAI_SUMMARY_MODEL=
-
-# Codex Task Model (Demo 3)
-# Model used for generating code changes in @codex tasks
-# Recommend a capable coding model
-# Leave blank to use default (gpt-4o-mini)
-OPENAI_CODEX_MODEL=
-
-# Chat Intent Detection (Demo 2 - Conversational Retrieval)
-# Model used for detecting chat-retrieval intent
-# Recommend a fast model for quick classification
-# Leave blank to use default (gpt-5-nano)
-OPENAI_CHAT_INTENT_MODEL=
-
-# Chat Finder (Demo 2 - Conversational Retrieval)
-# Model used for reranking chat candidates
-# Recommend a fast but capable model
-# Leave blank to use default (gpt-5-mini)
-OPENAI_CHAT_FINDER_MODEL=
-
-# Maximum candidates for lexical pre-filtering (default: 30, max: 60)
-OPENAI_CHAT_FINDER_MAX_CANDIDATES=
-
-# Top K results to return from reranking (default: 5)
-OPENAI_CHAT_FINDER_TOPK=
+# =============================================================================
+# Legacy Configuration (deprecated, kept for reference)
+# =============================================================================
+# These are no longer used by the centralized OpenAI client but kept for reference.
+# The new model-per-request-type configuration above is the preferred approach.
+#
+# OPENAI_MODEL=gpt-4o
+# OPENAI_REASONING_FAST=low
+# OPENAI_REASONING_DEEP=medium
+# OPENAI_TEXT_VERBOSITY=low
+# OPENAI_STACKS_MODEL=
+# OPENAI_SUMMARY_MODEL=
+# OPENAI_CODEX_MODEL=
+# OPENAI_CHAT_INTENT_MODEL=
+# OPENAI_CHAT_FINDER_MODEL=

--- a/app/api/chats/find/route.ts
+++ b/app/api/chats/find/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
-import OpenAI from "openai"
 import { z } from "zod"
-import { zodTextFormat } from "openai/helpers/zod"
 import { getChatStore } from "@/lib/store"
 import type { StoredChatThreadMeta } from "@/lib/store"
+import { createParsedResponse, formatOpenAIError, getConfigInfo } from "@/lib/openai"
 
 // ---------------------------------------------------------------------------
 // POST /api/chats/find
@@ -53,7 +52,6 @@ interface FindResponse {
 }
 
 // Defaults
-const DEFAULT_FINDER_MODEL = "gpt-5-mini"
 const DEFAULT_MAX_CANDIDATES = 30
 const DEFAULT_TOPK = 5
 const MAX_CANDIDATES_CAP = 60
@@ -222,15 +220,6 @@ export async function POST(request: NextRequest) {
 
     const topK = envTopK ? parseInt(envTopK, 10) : DEFAULT_TOPK
 
-    // Check for API key
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: "OpenAI API key not configured" },
-        { status: 500 }
-      )
-    }
-
     // Step A: Load all chats and generate candidates locally
     const store = getChatStore()
     const allChats = await store.listThreads(demoUid)
@@ -247,23 +236,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(response)
     }
 
-    // Step B: LLM rerank
-    const openai = new OpenAI({ apiKey })
-    const model = process.env.OPENAI_CHAT_FINDER_MODEL || DEFAULT_FINDER_MODEL
-
+    // Step B: LLM rerank using centralized client
     const prompt = buildRerankPrompt(query, candidates, topK)
+    const config = getConfigInfo("finder")
 
-    const llmResponse = await openai.responses.parse({
-      model,
+    console.log(`[POST /api/chats/find] Reranking ${candidates.length} candidates with model ${config.model}`)
+
+    const { parsed } = await createParsedResponse({
+      kind: "finder",
       input: prompt,
-      store: false,
-      reasoning: { effort: "none" },
-      text: {
-        format: zodTextFormat(RerankOutputSchema, "rerank_results"),
-      },
+      schema: RerankOutputSchema,
+      schemaName: "rerank_results",
     })
-
-    const parsed = llmResponse.output_parsed as RerankOutput | null
 
     if (!parsed) {
       console.error("[POST /api/chats/find] Failed to parse rerank output")
@@ -310,16 +294,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("[POST /api/chats/find] Error:", error)
 
-    if (error instanceof OpenAI.APIError) {
-      return NextResponse.json(
-        { error: `OpenAI API error: ${error.message}` },
-        { status: error.status || 500 }
-      )
-    }
-
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 }
-    )
+    const errorResponse = formatOpenAIError(error, "finder")
+    return NextResponse.json(errorResponse, { status: 500 })
   }
 }

--- a/app/api/respond/route.ts
+++ b/app/api/respond/route.ts
@@ -1,5 +1,14 @@
 import { NextRequest, NextResponse } from "next/server"
 import OpenAI from "openai"
+import {
+  getOpenAIClient,
+  getModel,
+  getReasoningEffort,
+  getTextVerbosity,
+  extractTextOutput,
+  formatOpenAIError,
+  type RequestKind,
+} from "@/lib/openai"
 
 export const runtime = "nodejs"
 
@@ -12,6 +21,8 @@ interface RespondRequest {
 }
 
 export async function POST(request: NextRequest) {
+  let kind: RequestKind = "chat_deep"
+
   try {
     const body = (await request.json()) as RespondRequest
 
@@ -22,121 +33,57 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: "OpenAI API key not configured" },
-        { status: 500 }
-      )
-    }
-
-    const openai = new OpenAI({ apiKey })
-
-    const model = process.env.OPENAI_MODEL || "gpt-4o"
     const mode = body.mode || "deep"
+    kind = mode === "fast" ? "chat_fast" : "chat_deep"
 
-    const reasoningEffort =
-      mode === "fast"
-        ? process.env.OPENAI_REASONING_FAST || "low"
-        : process.env.OPENAI_REASONING_DEEP || "medium"
-
-    // Check if model supports reasoning
-    const supportsReasoning = /^(o[13](-|$)|gpt-5)/.test(model)
-    
-    // Use text.verbosity to guide response length (not max_output_tokens which causes hard cutoffs)
-    // Default to "low" for concise responses that complete naturally without truncation
-    const textVerbosity = process.env.OPENAI_TEXT_VERBOSITY || "low"
-    
-    // max_output_tokens is only used as a safety limit to prevent runaway costs
-    // Set very high so it doesn't interfere with natural response completion
-    // If not set, don't include it at all (let model use its default)
-    const maxOutputTokens = process.env.OPENAI_MAX_OUTPUT_TOKENS 
-      ? parseInt(process.env.OPENAI_MAX_OUTPUT_TOKENS, 10)
-      : null
+    const openai = getOpenAIClient()
+    const model = getModel(kind)
+    const reasoningEffort = getReasoningEffort(kind)
+    const textVerbosity = getTextVerbosity(kind)
 
     const requestParams: OpenAI.Responses.ResponseCreateParams = {
       model,
       input: [{ role: "user", content: body.input }],
       instructions: SYSTEM_INSTRUCTIONS,
       store: true,
-    }
-    
-    // Only set max_output_tokens if explicitly configured (as a cost safety limit)
-    // Otherwise, let the model complete naturally guided by verbosity and instructions
-    if (maxOutputTokens) {
-      requestParams.max_output_tokens = maxOutputTokens
+      reasoning: { effort: reasoningEffort },
+      text: {
+        format: { type: "text" },
+        verbosity: textVerbosity,
+      },
     }
 
     if (body.previous_response_id) {
       requestParams.previous_response_id = body.previous_response_id
     }
 
-    // Only include reasoning.effort for models that support it:
-    // - o1, o3 series (reasoning models)
-    // - gpt-5 series (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-medium, gpt-5-pro, gpt-5.1, etc.)
-    // NOT supported by: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo, etc.
-    if (supportsReasoning && reasoningEffort && reasoningEffort !== "none") {
-      requestParams.reasoning = {
-        effort: reasoningEffort as "low" | "medium" | "high",
-      }
-    }
-
-    // Configure text output verbosity to guide response length naturally
-    // This is the primary mechanism for controlling response length without hard cutoffs
-    // "low" = concise responses, "medium" = balanced, "high" = detailed
-    if (["low", "medium", "high"].includes(textVerbosity)) {
-      requestParams.text = {
-        format: { type: "text" },
-        verbosity: textVerbosity as "low" | "medium" | "high",
-      }
-    }
-
     // Debug: Log request params
-    console.log("OpenAI Request:", {
-      model: requestParams.model,
-      reasoningEffort: requestParams.reasoning?.effort || "none",
-      textVerbosity: requestParams.text?.verbosity || "default",
-      maxOutputTokens: requestParams.max_output_tokens || "unlimited",
+    console.log(`[OpenAI:${kind}] Request:`, {
+      model,
+      reasoning: reasoningEffort,
+      verbosity: textVerbosity,
       hasPreviousResponseId: !!requestParams.previous_response_id,
     })
 
     const response = await openai.responses.create(requestParams)
 
-    // Debug: Log response structure to help diagnose empty responses
-    console.log("OpenAI Response:", {
+    // Debug: Log response structure
+    console.log(`[OpenAI:${kind}] Response:`, {
       id: response.id,
       status: response.status,
-      output_text: response.output_text,
-      output_count: response.output?.length,
-      output_types: response.output?.map((item) => item.type),
       model: response.model,
     })
 
-    const outputText =
-      response.output_text ||
-      response.output
-        ?.filter((item): item is OpenAI.Responses.ResponseOutputMessage =>
-          item.type === "message"
-        )
-        .flatMap((msg) =>
-          msg.content
-            .filter((c): c is OpenAI.Responses.ResponseOutputText =>
-              c.type === "output_text"
-            )
-            .map((c) => c.text)
-        )
-        .join("") ||
-      ""
+    const outputText = extractTextOutput(response)
 
     // Debug: Log if output is empty or incomplete
     if (!outputText) {
       console.warn("Empty output_text. Full response output:", JSON.stringify(response.output, null, 2))
     }
-    
+
     if (response.status === "incomplete") {
       console.warn("Response incomplete:", {
         reason: response.incomplete_details,
-        suggestion: "If due to max_output_tokens, increase OPENAI_MAX_OUTPUT_TOKENS or remove it entirely",
       })
     }
 
@@ -147,16 +94,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("API error:", error)
 
-    if (error instanceof OpenAI.APIError) {
-      return NextResponse.json(
-        { error: `OpenAI API error: ${error.message}` },
-        { status: error.status || 500 }
-      )
-    }
-
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 }
-    )
+    const errorResponse = formatOpenAIError(error, kind)
+    return NextResponse.json(errorResponse, { status: 500 })
   }
 }

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
-import OpenAI from "openai"
+import {
+  createTextResponse,
+  extractTextOutput,
+  formatOpenAIError,
+} from "@/lib/openai"
 
 export const runtime = "nodejs"
 
@@ -32,17 +36,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ summary: "" })
     }
 
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: "OpenAI API key not configured" },
-        { status: 500 }
-      )
-    }
-
-    const openai = new OpenAI({ apiKey })
-    const model = process.env.OPENAI_MODEL || "gpt-4o"
-
     // Build conversation transcript for summarization
     const transcript = body.branchMessages
       .map((msg) => `${msg.role === "user" ? "User" : "Assistant"}: ${msg.text}`)
@@ -51,31 +44,14 @@ export async function POST(request: NextRequest) {
     const maxBullets = body.maxBullets || 5
     const prompt = `${SUMMARIZE_PROMPT}\n\nLimit to ${maxBullets} bullets maximum.\n\nConversation:\n${transcript}`
 
-    // Use Responses API without previous_response_id (stateless summarize)
-    const response = await openai.responses.create({
-      model,
+    // Use centralized client for summarization
+    const response = await createTextResponse({
+      kind: "summarize",
       input: [{ role: "user", content: prompt }],
       instructions: "You are a concise summarizer. Output only bullet points, nothing else.",
-      max_output_tokens: 300,
-      // No previous_response_id - stateless call
-      // No reasoning effort - simple task
     })
 
-    const outputText =
-      response.output_text ||
-      response.output
-        ?.filter((item): item is OpenAI.Responses.ResponseOutputMessage =>
-          item.type === "message"
-        )
-        .flatMap((msg) =>
-          msg.content
-            .filter((c): c is OpenAI.Responses.ResponseOutputText =>
-              c.type === "output_text"
-            )
-            .map((c) => c.text)
-        )
-        .join("") ||
-      ""
+    const outputText = extractTextOutput(response)
 
     return NextResponse.json({
       summary: outputText.trim(),
@@ -83,16 +59,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Summarize API error:", error)
 
-    if (error instanceof OpenAI.APIError) {
-      return NextResponse.json(
-        { error: `OpenAI API error: ${error.message}` },
-        { status: error.status || 500 }
-      )
-    }
-
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 }
-    )
+    const errorResponse = formatOpenAIError(error, "summarize")
+    return NextResponse.json(errorResponse, { status: 500 })
   }
 }

--- a/lib/openai/client.ts
+++ b/lib/openai/client.ts
@@ -1,0 +1,397 @@
+/**
+ * Centralized OpenAI client and request configuration
+ *
+ * This module provides:
+ * - Singleton OpenAI client
+ * - Request kind-based configuration
+ * - Safe reasoning/verbosity parameters
+ * - Consistent error handling
+ */
+
+import OpenAI from "openai"
+import { z } from "zod"
+import { zodTextFormat } from "openai/helpers/zod"
+
+// =============================================================================
+// Request Kinds
+// =============================================================================
+
+/**
+ * Request kinds with pre-configured settings
+ */
+export type RequestKind =
+  | "chat_fast" // Fast chat responses (gpt-5-nano, reasoning: low, verbosity: low)
+  | "chat_deep" // Deep chat responses (gpt-5-mini, reasoning: medium, verbosity: low)
+  | "summarize" // Summarization tasks (gpt-5-nano, reasoning: low, verbosity: low)
+  | "intent" // Intent classification (gpt-5-nano, reasoning: low, verbosity: low)
+  | "stacks" // Smart Stacks categorization (gpt-5-nano, reasoning: low, verbosity: low)
+  | "finder" // Chat finder reranking (gpt-5-mini, reasoning: low, verbosity: low)
+  | "codex" // Codex tasks (gpt-5.1-codex-mini, reasoning: medium)
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Default models for each request kind
+ */
+const DEFAULT_MODELS: Record<RequestKind, string> = {
+  chat_fast: "gpt-5-nano",
+  chat_deep: "gpt-5-mini",
+  summarize: "gpt-5-nano",
+  intent: "gpt-5-nano",
+  stacks: "gpt-5-nano",
+  finder: "gpt-5-mini",
+  codex: "gpt-5.1-codex-mini",
+}
+
+/**
+ * Environment variable names for model overrides
+ */
+const MODEL_ENV_VARS: Record<RequestKind, string> = {
+  chat_fast: "OPENAI_MODEL_FAST",
+  chat_deep: "OPENAI_MODEL_DEEP",
+  summarize: "OPENAI_MODEL_SUMMARIZE",
+  intent: "OPENAI_MODEL_INTENT",
+  stacks: "OPENAI_MODEL_STACKS",
+  finder: "OPENAI_MODEL_FINDER",
+  codex: "OPENAI_MODEL_CODEX",
+}
+
+/**
+ * Reasoning effort for each request kind
+ * Note: GPT-5 models require "low" or higher, NOT "none"
+ */
+const REASONING_EFFORT: Record<RequestKind, "low" | "medium" | "high"> = {
+  chat_fast: "low",
+  chat_deep: "medium",
+  summarize: "low",
+  intent: "low",
+  stacks: "low",
+  finder: "low",
+  codex: "medium",
+}
+
+/**
+ * Text verbosity for each request kind
+ */
+const TEXT_VERBOSITY: Record<RequestKind, "low" | "medium" | "high"> = {
+  chat_fast: "low",
+  chat_deep: "low",
+  summarize: "low",
+  intent: "low",
+  stacks: "low",
+  finder: "low",
+  codex: "medium",
+}
+
+// =============================================================================
+// Client
+// =============================================================================
+
+let openaiClient: OpenAI | null = null
+
+/**
+ * Get the singleton OpenAI client
+ * Throws if OPENAI_API_KEY is not configured
+ */
+export function getOpenAIClient(): OpenAI {
+  if (openaiClient) {
+    return openaiClient
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY not configured")
+  }
+
+  openaiClient = new OpenAI({ apiKey })
+  return openaiClient
+}
+
+// =============================================================================
+// Configuration Helpers
+// =============================================================================
+
+/**
+ * Get the model for a request kind
+ */
+export function getModel(kind: RequestKind): string {
+  const envVar = MODEL_ENV_VARS[kind]
+  return process.env[envVar] || DEFAULT_MODELS[kind]
+}
+
+/**
+ * Get the reasoning effort for a request kind
+ */
+export function getReasoningEffort(kind: RequestKind): "low" | "medium" | "high" {
+  return REASONING_EFFORT[kind]
+}
+
+/**
+ * Get the text verbosity for a request kind
+ */
+export function getTextVerbosity(kind: RequestKind): "low" | "medium" | "high" {
+  return TEXT_VERBOSITY[kind]
+}
+
+/**
+ * Get configuration info for logging
+ */
+export function getConfigInfo(kind: RequestKind): {
+  model: string
+  reasoning: string
+  verbosity: string
+} {
+  return {
+    model: getModel(kind),
+    reasoning: getReasoningEffort(kind),
+    verbosity: getTextVerbosity(kind),
+  }
+}
+
+// =============================================================================
+// Request Builders
+// =============================================================================
+
+export interface BaseRequestOptions {
+  kind: RequestKind
+  input: string | OpenAI.Responses.ResponseInput
+  previousResponseId?: string | null
+  instructions?: string
+}
+
+export interface TextRequestOptions extends BaseRequestOptions {
+  type: "text"
+}
+
+export interface ParseRequestOptions<T extends z.ZodType> extends BaseRequestOptions {
+  type: "parse"
+  schema: T
+  schemaName: string
+}
+
+export type RequestOptions<T extends z.ZodType = z.ZodNever> =
+  | TextRequestOptions
+  | ParseRequestOptions<T>
+
+/**
+ * Non-streaming response create params
+ */
+type NonStreamingResponseParams = OpenAI.Responses.ResponseCreateParamsNonStreaming
+
+/**
+ * Build common request parameters for a given kind
+ */
+function buildCommonParams(
+  kind: RequestKind,
+  input: string | OpenAI.Responses.ResponseInput,
+  options?: {
+    previousResponseId?: string | null
+    instructions?: string
+  }
+): NonStreamingResponseParams {
+  const model = getModel(kind)
+  const reasoning = getReasoningEffort(kind)
+  const verbosity = getTextVerbosity(kind)
+
+  const params: NonStreamingResponseParams = {
+    model,
+    input,
+    store: false,
+    stream: false,
+    reasoning: { effort: reasoning },
+    text: {
+      format: { type: "text" },
+      verbosity,
+    },
+  }
+
+  if (options?.previousResponseId) {
+    params.previous_response_id = options.previousResponseId
+  }
+
+  if (options?.instructions) {
+    params.instructions = options.instructions
+  }
+
+  return params
+}
+
+/**
+ * Create a text response request
+ */
+export async function createTextResponse(options: {
+  kind: RequestKind
+  input: string | OpenAI.Responses.ResponseInput
+  previousResponseId?: string | null
+  instructions?: string
+}): Promise<OpenAI.Responses.Response> {
+  const client = getOpenAIClient()
+  const params = buildCommonParams(options.kind, options.input, {
+    previousResponseId: options.previousResponseId,
+    instructions: options.instructions,
+  })
+
+  const config = getConfigInfo(options.kind)
+  console.log(`[OpenAI:${options.kind}] Request:`, {
+    model: config.model,
+    reasoning: config.reasoning,
+    verbosity: config.verbosity,
+    hasPreviousResponseId: !!options.previousResponseId,
+  })
+
+  try {
+    const response = await client.responses.create(params)
+
+    console.log(`[OpenAI:${options.kind}] Response:`, {
+      id: response.id,
+      status: response.status,
+      model: response.model,
+    })
+
+    return response
+  } catch (error) {
+    handleOpenAIError(error, options.kind, config)
+    throw error
+  }
+}
+
+/**
+ * Create a parsed (structured output) response request
+ */
+export async function createParsedResponse<T extends z.ZodType>(options: {
+  kind: RequestKind
+  input: string | OpenAI.Responses.ResponseInput
+  schema: T
+  schemaName: string
+  previousResponseId?: string | null
+  instructions?: string
+}): Promise<{
+  response: OpenAI.Responses.Response
+  parsed: z.infer<T> | null
+}> {
+  const client = getOpenAIClient()
+  const model = getModel(options.kind)
+  const reasoning = getReasoningEffort(options.kind)
+
+  const config = getConfigInfo(options.kind)
+  console.log(`[OpenAI:${options.kind}] Parse request:`, {
+    model: config.model,
+    reasoning: config.reasoning,
+    schema: options.schemaName,
+  })
+
+  try {
+    const response = await client.responses.parse({
+      model,
+      input: options.input,
+      store: false,
+      reasoning: { effort: reasoning },
+      text: {
+        format: zodTextFormat(options.schema, options.schemaName),
+      },
+    })
+
+    console.log(`[OpenAI:${options.kind}] Parse response:`, {
+      id: response.id,
+      status: response.status,
+      model: response.model,
+      hasParsed: !!response.output_parsed,
+    })
+
+    return {
+      response,
+      parsed: response.output_parsed as z.infer<T> | null,
+    }
+  } catch (error) {
+    handleOpenAIError(error, options.kind, config)
+    throw error
+  }
+}
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+/**
+ * Handle OpenAI API errors with detailed logging
+ */
+function handleOpenAIError(
+  error: unknown,
+  kind: RequestKind,
+  config: { model: string; reasoning: string; verbosity: string }
+): void {
+  if (error instanceof OpenAI.APIError) {
+    console.error(`[OpenAI:${kind}] API Error:`, {
+      route: kind,
+      model: config.model,
+      reasoning: config.reasoning,
+      verbosity: config.verbosity,
+      status: error.status,
+      message: error.message,
+      code: error.code,
+      requestId: error.headers?.["x-request-id"],
+    })
+  } else {
+    console.error(`[OpenAI:${kind}] Unknown Error:`, error)
+  }
+}
+
+/**
+ * Format an OpenAI error for API response
+ */
+export function formatOpenAIError(error: unknown, kind: RequestKind): {
+  error: string
+  details?: {
+    route: string
+    model: string
+    reasoning: string
+  }
+} {
+  const config = getConfigInfo(kind)
+
+  if (error instanceof OpenAI.APIError) {
+    return {
+      error: `OpenAI API error: ${error.message}`,
+      details: {
+        route: kind,
+        model: config.model,
+        reasoning: config.reasoning,
+      },
+    }
+  }
+
+  return {
+    error: error instanceof Error ? error.message : "Unknown error",
+  }
+}
+
+// =============================================================================
+// Response Helpers
+// =============================================================================
+
+/**
+ * Extract text output from a response
+ */
+export function extractTextOutput(response: OpenAI.Responses.Response): string {
+  // Try output_text first (convenience property)
+  if (response.output_text) {
+    return response.output_text
+  }
+
+  // Fall back to extracting from output array
+  if (response.output) {
+    for (const item of response.output) {
+      if (item.type === "message" && item.content) {
+        for (const content of item.content) {
+          if (content.type === "output_text") {
+            return content.text
+          }
+        }
+      }
+    }
+  }
+
+  return ""
+}

--- a/lib/openai/index.ts
+++ b/lib/openai/index.ts
@@ -1,0 +1,20 @@
+/**
+ * OpenAI module exports
+ */
+
+export {
+  getOpenAIClient,
+  getModel,
+  getReasoningEffort,
+  getTextVerbosity,
+  getConfigInfo,
+  createTextResponse,
+  createParsedResponse,
+  formatOpenAIError,
+  extractTextOutput,
+  type RequestKind,
+  type BaseRequestOptions,
+  type TextRequestOptions,
+  type ParseRequestOptions,
+  type RequestOptions,
+} from "./client"


### PR DESCRIPTION
…reasoning + codex GPT-5 model

- Create lib/openai/client.ts with centralized request configuration
- Fix reasoning.effort: "none" error by using "low" for gpt-5-nano
- Add request kinds: chat_fast, chat_deep, summarize, intent, stacks, finder, codex
- Each kind has pre-configured model, reasoning effort, and text verbosity
- Update all API routes to use the centralized client
- Add better error logging with route, model, and reasoning details
- Update .env.example with new OPENAI_MODEL_* environment variables