### PR TITLE
Chained response reliability fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,23 @@ OPENAI_API_KEY=
 #
 # IMPORTANT: GPT-5 series models do NOT support reasoning.effort: "none"
 # The minimum is "low". The client handles this automatically.
+#
+# IMPORTANT: Chat kinds (fast/deep) use the SAME underlying model to ensure
+# previous_response_id chaining works. Fast vs Deep is controlled via
+# reasoning.effort, not by swapping models.
+
+# Unified chat model for all chained conversations (fast + deep)
+# If set, overrides both OPENAI_MODEL_FAST and OPENAI_MODEL_DEEP.
+# Default: gpt-5-mini
+OPENAI_MODEL_CHAT=gpt-5-mini
 
 # Fast chat responses (branch "fast" mode, quick answers)
-# Default: gpt-5-nano | Reasoning: low | Verbosity: low
-OPENAI_MODEL_FAST=gpt-5-nano
+# NOTE: If OPENAI_MODEL_CHAT is set, this is ignored for chat requests.
+# Default: gpt-5-mini | Reasoning: low | Verbosity: low
+OPENAI_MODEL_FAST=gpt-5-mini
 
 # Deep chat responses (main chat, thorough answers)
+# NOTE: If OPENAI_MODEL_CHAT is set, this is ignored for chat requests.
 # Default: gpt-5-mini | Reasoning: medium | Verbosity: low
 OPENAI_MODEL_DEEP=gpt-5-mini
 

--- a/lib/openai/index.ts
+++ b/lib/openai/index.ts
@@ -30,6 +30,7 @@ export {
 
   // Configuration
   getModel,
+  getChainedChatModel,
   getReasoningEffort,
   getTextVerbosity,
   getConfigInfo,


### PR DESCRIPTION
Ensures reliable chat and branch conversations by fixing `previous_response_id` chaining and unifying chat models.

The `previous_response_id` mechanism, crucial for branching and follow-ups, was failing due to responses not being stored by OpenAI (a global `store: false` setting) and `chat_fast`/`chat_deep` potentially using different underlying models, which breaks the chain when switching. This PR addresses both root causes and adds a graceful recovery path for unexpected chain breaks.

---
<a href="https://cursor.com/background-agent?bcId=bc-447b43de-b48f-4cbf-ac0f-3a2a05057e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-447b43de-b48f-4cbf-ac0f-3a2a05057e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

