### PR TITLE
Fix model configuration in chat feature

### DIFF
--- a/lib/openai/client.ts
+++ b/lib/openai/client.ts
@@ -132,7 +132,7 @@ export function getChainedChatModel(): string {
  */
 const REASONING_EFFORT: Record<RequestKind, "low" | "medium" | "high"> = {
   chat_fast: "low",
-  chat_deep: "medium",
+  chat_deep: "high",
   summarize: "low",
   intent: "low",
   stacks: "low",


### PR DESCRIPTION
Changes:
- chat_deep reasoning effort: "medium" → "high"
- chat_fast remains "low" (unchanged)
- Both modes now use same model (configurable via OPENAI_MODEL_CHAT)

This allows Fast/Deep mode switching without breaking previous_response_id chaining, while still providing meaningful performance differentiation.