### PR TITLE
perf: eliminate 30s latency in branch merge by skipping LLM ingestion…

### DIFF
--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { GitBranch, GitMerge, List, FileText } from "lucide-react"
+import { GitBranch, GitMerge } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -40,42 +40,17 @@ export function ChatMessageBubble({
     }
   }
 
-  // Render context card for merged branch content
+  // Render compact context indicator for merged branch content
   if (isContext && message.contextMeta) {
-    const { branchTitle, mergeType } = message.contextMeta
-    const isSummary = mergeType === "summary"
+    const { branchTitle } = message.contextMeta
 
     return (
       <div className="flex w-full justify-center animate-chip-in">
-        <div className="max-w-[90%] w-full">
-          <div className="bg-gradient-to-r from-emerald-500/5 via-emerald-500/10 to-emerald-500/5 dark:from-emerald-500/10 dark:via-emerald-500/15 dark:to-emerald-500/10 border border-emerald-500/20 rounded-xl px-4 py-3">
-            {/* Header */}
-            <div className="flex items-center gap-2 mb-2">
-              <div className="flex items-center justify-center w-6 h-6 rounded-full bg-emerald-500/20">
-                <GitMerge className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <span className="text-xs font-medium text-emerald-700 dark:text-emerald-300">
-                Context merged from &ldquo;{branchTitle}&rdquo;
-              </span>
-              <span className="ml-auto flex items-center gap-1 text-[10px] text-emerald-600/70 dark:text-emerald-400/70">
-                {isSummary ? (
-                  <>
-                    <List className="h-2.5 w-2.5" />
-                    summary
-                  </>
-                ) : (
-                  <>
-                    <FileText className="h-2.5 w-2.5" />
-                    full
-                  </>
-                )}
-              </span>
-            </div>
-            {/* Content */}
-            <div className="text-sm text-foreground/80 whitespace-pre-wrap leading-relaxed">
-              {message.text}
-            </div>
-          </div>
+        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20">
+          <GitMerge className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+          <span className="text-xs text-emerald-700 dark:text-emerald-300">
+            Branch &ldquo;{branchTitle}&rdquo; context added
+          </span>
         </div>
       </div>
     )


### PR DESCRIPTION
… call

The root cause of the slow "include in main chat" functionality was that after skipping summarization for short branches, we were still calling /api/respond with mode: "deep" to "ingest" the context - triggering a full LLM response that took 30+ seconds.

The fix:
- Store pending branch context in a ref instead of calling LLM immediately
- Prepend the context to the user's next message automatically
- Display a compact context indicator in the UI (just a pill badge)
- Only show loading overlay when LLM summarization is needed (longer chats)

This makes branch merging essentially instant for short conversations and only requires a wait for longer ones that need LLM summarization.