### PR TITLE
Fix placeholder task polling: stop placeholder_... 404 spam and ensure reliable ingestion

### DIFF
--- a/app/demos/codex/page.tsx
+++ b/app/demos/codex/page.tsx
@@ -349,6 +349,12 @@ export default function CodexDemoPage() {
 
         const task = data.task as CodexTask
 
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            `[Codex:handleSend] Replacing placeholder task "${placeholderId}" with real task "${task.id}"`
+          )
+        }
+
         // Replace placeholder with real task
         setTasks((prev) => {
           const { [placeholderId]: _, ...rest } = prev
@@ -533,7 +539,7 @@ export default function CodexDemoPage() {
                     if (!task) return null
                     return (
                       <TaskCard
-                        key={message.id}
+                        key={`${message.id}-${message.taskId}`}
                         task={task}
                         workspace={workspace || undefined}
                         onApplyChanges={() => applyTaskChanges(task.id)}

--- a/app/demos/unified/page.tsx
+++ b/app/demos/unified/page.tsx
@@ -854,6 +854,12 @@ function UnifiedDemoContent() {
 
       const task = data.task as CodexTask
 
+      if (process.env.NODE_ENV === "development") {
+        console.log(
+          `[Unified:handleCodexCommand] Replacing placeholder task "${placeholderId}" with real task "${task.id}"`
+        )
+      }
+
       // Replace placeholder with real task
       setTasks((prev) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1341,7 +1347,7 @@ function UnifiedDemoContent() {
                   if (!task) return null
                   return (
                     <TaskCard
-                      key={message.localId}
+                      key={`${message.localId}-${message.taskId}`}
                       task={task}
                       workspace={workspace || undefined}
                       onApplyChanges={() => applyTaskChanges(task.id)}

--- a/components/codex/task-card.tsx
+++ b/components/codex/task-card.tsx
@@ -485,13 +485,17 @@ function ProgressView({
 
   // Auto-refresh periodically
   useEffect(() => {
+    if (task.id.startsWith("placeholder_")) {
+      return
+    }
+
     const interval = setInterval(() => {
       setIsRefreshing(true)
       onRefresh().finally(() => setIsRefreshing(false))
     }, 3000)
 
     return () => clearInterval(interval)
-  }, [onRefresh])
+  }, [onRefresh, task.id])
 
   // Calculate time-based progress (never completes since component unmounts when task finishes)
   const progress = calculateTimeBasedProgress(elapsedMs, false)


### PR DESCRIPTION
### Motivation
- Prevent client-side placeholder IDs like `placeholder_*` from triggering server fetches that return 404s and create noisy logs. 
- Ensure polling/refresh timers are tied to the real task ID so ingestion and refresh logic run reliably after the placeholder -> real task replacement.

### Description
- Skip the auto-refresh interval in `TaskCard` when `task.id` starts with `placeholder_` and add `task.id` to the `useEffect` deps so the interval is cleared and restarted when the ID changes. 
- Add development `console.log` entries when replacing a placeholder with a real task in `app/demos/codex/page.tsx` and `app/demos/unified/page.tsx`. 
- Force `TaskCard` remounts on ID replacement by including the task ID in the `key` (changed keys to ```${message.id}-${message.taskId}``` and ```${message.localId}-${message.taskId}```) so polling timers reset under the real ID. 
- Small tidy: ensure `onRefresh` calls remain and the refreshed task continues to be used for ingestion as before.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc329f52c8326823d08adb0260d9e)