### PR TITLE
Set chat reasoning effort to low

### DIFF
--- a/lib/codex/MockTaskRunner.ts
+++ b/lib/codex/MockTaskRunner.ts
@@ -247,7 +247,7 @@ function generateUnifiedDiff(
  *
  * Uses the centralized OpenAI client with "codex" request kind:
  * - Model: gpt-5.1-codex-mini (or OPENAI_MODEL_CODEX env var)
- * - Reasoning effort: medium (NOT "none" - that causes 400 errors!)
+ * - Reasoning effort: low (NOT "none" - that causes 400 errors!)
  * - Text verbosity: medium
  */
 export class MockTaskRunner implements TaskRunner {
@@ -282,7 +282,7 @@ export class MockTaskRunner implements TaskRunner {
 
       console.log(`[MockTaskRunner] Starting task ${taskId} with model ${config.model} (reasoning: ${config.reasoning})`)
 
-      // Uses "codex" kind: gpt-5.1-codex-mini with reasoning: medium
+      // Uses "codex" kind: gpt-5.1-codex-mini with reasoning: low
       const { parsed } = await createParsedResponse({
         kind: "codex",
         input: fullPrompt,

--- a/lib/openai/client.ts
+++ b/lib/openai/client.ts
@@ -28,12 +28,12 @@ import { zodTextFormat } from "openai/helpers/zod"
  */
 export type RequestKind =
   | "chat_fast" // Fast chat responses (reasoning: low)
-  | "chat_deep" // Deep chat responses (reasoning: medium)
+  | "chat_deep" // Deep chat responses (reasoning: low)
   | "summarize" // Summarization tasks (gpt-5-nano, reasoning: low)
   | "intent" // Intent classification (gpt-5-nano, reasoning: low)
   | "stacks" // Smart Stacks categorization (gpt-5-nano, reasoning: low)
   | "finder" // Chat finder reranking (gpt-5-mini, reasoning: low)
-  | "codex" // Codex tasks (gpt-5.1-codex-mini, reasoning: medium)
+  | "codex" // Codex tasks (gpt-5.1-codex-mini, reasoning: low)
 
 /**
  * Request kinds that use previous_response_id chaining.
@@ -139,7 +139,7 @@ type ReasoningEffort = "minimal" | "low" | "medium" | "high"
  */
 const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
   chat_fast: "low",
-  chat_deep: "high",
+  chat_deep: "low",
   summarize: "minimal", // Use minimal for fastest summarization
   intent: "low",
   stacks: "low",


### PR DESCRIPTION
### Motivation
- Standardize reasoning effort to `low` for chained chat kinds so the main unified chat and branch chats default to the same lower-effort setting and align in-code comments with the configured defaults.

### Description
- Updated `lib/openai/client.ts` to set `chat_deep` reasoning to `low` in the `REASONING_EFFORT` mapping and adjusted the `RequestKind` comment for `chat_deep`, and updated `lib/codex/MockTaskRunner.ts` comments to reflect `low` reasoning for the `codex` flow.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc5b746f083269b8e46c1d085d9d5)