### PR TITLE
feat: Unified Chat UI with sidebar and demos dropdown

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
 
 export default function Home() {
-  redirect("/demos/branches")
+  redirect("/demos/unified")
 }

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -7,12 +7,12 @@ import {
   GitBranch,
   History,
   Terminal,
-  Zap,
   Sun,
   Moon,
   Database,
   HardDrive,
   AlertTriangle,
+  ChevronDown,
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
@@ -22,9 +22,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 
-const navItems = [
+const demoItems = [
   {
     href: "/demos/branches",
     label: "Branches",
@@ -39,11 +45,6 @@ const navItems = [
     href: "/demos/codex",
     label: "Codex",
     icon: Terminal,
-  },
-  {
-    href: "/demos/unified",
-    label: "Unified",
-    icon: Zap,
   },
 ]
 
@@ -179,6 +180,10 @@ export function Nav() {
   const pathname = usePathname()
   const { theme, setTheme } = useTheme()
 
+  // Check if current page is one of the individual demos
+  const isOnDemoPage = demoItems.some((item) => pathname === item.href)
+  const currentDemo = demoItems.find((item) => pathname === item.href)
+
   return (
     <nav className="flex items-center justify-between px-6 py-4 border-b border-border/50">
       <div className="flex items-center gap-1">
@@ -189,21 +194,44 @@ export function Nav() {
           LLM Chat Demos
         </Link>
         <div className="flex items-center gap-1">
-          {navItems.map((item) => {
-            const isActive = pathname === item.href
-            return (
-              <Link key={item.href} href={item.href}>
-                <Button
-                  variant={isActive ? "secondary" : "ghost"}
-                  size="sm"
-                  className={cn("gap-2", isActive && "bg-secondary")}
-                >
-                  <item.icon className="h-4 w-4" />
-                  {item.label}
-                </Button>
-              </Link>
-            )
-          })}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant={isOnDemoPage ? "secondary" : "ghost"}
+                size="sm"
+                className={cn("gap-2", isOnDemoPage && "bg-secondary")}
+              >
+                {currentDemo ? (
+                  <>
+                    <currentDemo.icon className="h-4 w-4" />
+                    {currentDemo.label}
+                  </>
+                ) : (
+                  "Demos"
+                )}
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {demoItems.map((item) => {
+                const isActive = pathname === item.href
+                return (
+                  <DropdownMenuItem key={item.href} asChild>
+                    <Link
+                      href={item.href}
+                      className={cn(
+                        "flex items-center gap-2 cursor-pointer",
+                        isActive && "bg-accent"
+                      )}
+                    >
+                      <item.icon className="h-4 w-4" />
+                      {item.label}
+                    </Link>
+                  </DropdownMenuItem>
+                )
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
       <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Make unified chat the default landing page (redirect `/` → `/demos/unified`)
- Add ChatGPT-style left sidebar showing chat history with titles and timestamps
- Replace flat navigation tabs with a "Demos" dropdown for Branches, History, Codex
- Auto-refresh sidebar when creating new chats

## Test plan
- [ ] Visit `/` → should redirect to `/demos/unified`
- [ ] Click "Demos" dropdown → Branches, History, Codex accessible
- [ ] Sidebar renders with chat list
- [ ] Click "New Chat" in sidebar → clears conversation
- [ ] Send messages → chat appears in sidebar after refresh
- [ ] Click a chat in sidebar → loads that conversation
- [ ] Individual demos work from dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)