### PR TITLE
Add Redis heartbeat cron job to prevent database archival

### DIFF
--- a/app/api/internal/redis-heartbeat/route.ts
+++ b/app/api/internal/redis-heartbeat/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Redis Heartbeat — Vercel Cron route
+ *
+ * Performs a single direct write to Upstash Redis once per day
+ * to prevent the database from being archived due to inactivity.
+ *
+ * This route intentionally BYPASSES the app's ResilientRedisStore
+ * (which can silently fall back to in-memory) and uses a fresh
+ * @vercel/kv client pointed at the real Upstash instance.
+ *
+ * Protected by CRON_SECRET (Bearer token).
+ */
+
+import { NextResponse } from "next/server"
+import { createClient } from "@vercel/kv"
+
+export const dynamic = "force-dynamic"
+
+const HEARTBEAT_KEY = "__system:redis_heartbeat"
+const TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
+
+function resolveRedisCredentials(): { url: string; token: string } {
+  // Upstash official (preferred)
+  const upstashUrl = process.env.UPSTASH_REDIS_REST_URL
+  const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN
+  if (upstashUrl && upstashToken) {
+    return { url: upstashUrl, token: upstashToken }
+  }
+
+  // Vercel KV fallback
+  const kvUrl = process.env.KV_REST_API_URL
+  const kvToken = process.env.KV_REST_API_TOKEN
+  if (kvUrl && kvToken) {
+    return { url: kvUrl, token: kvToken }
+  }
+
+  throw new Error(
+    "Redis credentials missing. Set UPSTASH_REDIS_REST_URL/TOKEN or KV_REST_API_URL/TOKEN."
+  )
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  // ── Auth ──────────────────────────────────────────────────
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    console.error("[redis-heartbeat] CRON_SECRET env var is not set")
+    return NextResponse.json(
+      { ok: false, error: "Server misconfigured: CRON_SECRET not set" },
+      { status: 500 }
+    )
+  }
+
+  const auth = request.headers.get("authorization")
+  if (auth !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 })
+  }
+
+  // ── Heartbeat ─────────────────────────────────────────────
+  try {
+    const { url, token } = resolveRedisCredentials()
+    const redis = createClient({ url, token })
+
+    const ranAt = new Date().toISOString()
+    await redis.set(HEARTBEAT_KEY, ranAt, { ex: TTL_SECONDS })
+
+    console.log(
+      `[redis-heartbeat] OK key=${HEARTBEAT_KEY} ranAt=${ranAt}`
+    )
+
+    return NextResponse.json({ ok: true, key: HEARTBEAT_KEY, ranAt })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[redis-heartbeat] FAIL error=${message}`)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/internal/redis-heartbeat",
+      "schedule": "17 5 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a daily cron job that performs a direct write to Upstash Redis to prevent the database from being archived due to inactivity. This is a critical maintenance task for production stability.

## Key Changes
- **New cron endpoint** (`/api/internal/redis-heartbeat`): A protected GET endpoint that writes a heartbeat timestamp to Redis with a 30-day TTL
  - Bypasses the app's `ResilientRedisStore` to ensure writes go directly to the real Upstash instance (not in-memory fallback)
  - Protected by `CRON_SECRET` Bearer token authentication
  - Supports both Upstash official credentials and Vercel KV fallback
  - Includes comprehensive error handling and logging

- **Vercel cron configuration** (`vercel.json`): Schedules the heartbeat to run daily at 05:17 UTC

## Implementation Details
- Uses `@vercel/kv` client to create a fresh connection directly to Redis credentials
- Credential resolution prioritizes `UPSTASH_REDIS_REST_URL/TOKEN` over `KV_REST_API_URL/TOKEN`
- Heartbeat key (`__system:redis_heartbeat`) is prefixed to indicate system usage
- TTL set to 30 days to maintain a recent activity record
- Route marked as `force-dynamic` to ensure it runs fresh on each invocation
- Comprehensive logging for monitoring and debugging

https://claude.ai/code/session_01WswGSCkuTfWFAxdMJd8iDs