### PR TITLE
fix: codex context, chat load resilience, and auto-title generation

### DIFF
--- a/app/api/chats/generate-title/route.ts
+++ b/app/api/chats/generate-title/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createTextResponse, extractTextOutput, getConfigInfo } from "@/lib/openai"
+
+export const runtime = "nodejs"
+
+const TITLE_PROMPT = `Generate a short, descriptive chat title (4-8 words) for this conversation. Output ONLY the title text, nothing else. No quotes, no prefix, no punctuation at the end.`
+
+interface GenerateTitleRequest {
+  userMessage: string
+  assistantMessage: string
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as GenerateTitleRequest
+
+    if (!body.userMessage || !body.assistantMessage) {
+      return NextResponse.json(
+        { error: "Missing userMessage or assistantMessage" },
+        { status: 400 }
+      )
+    }
+
+    const transcript = `User: ${body.userMessage}\nAssistant: ${body.assistantMessage}`
+    const prompt = `${TITLE_PROMPT}\n\n${transcript}`
+
+    // Use the lightweight summarize model (gpt-5-nano) — fast and cheap
+    const config = getConfigInfo("summarize")
+    if (process.env.NODE_ENV === "development") {
+      console.log(`[GenerateTitle] Using model: ${config.model}`)
+    }
+
+    const response = await createTextResponse({
+      kind: "summarize",
+      input: [{ role: "user", content: prompt }],
+      instructions: "You are a chat title generator. Output only the title, nothing else.",
+      storeOverride: false,
+    })
+
+    const title = extractTextOutput(response).trim().replace(/^["']|["']$/g, "")
+
+    return NextResponse.json({ title })
+  } catch (error) {
+    console.error("[GenerateTitle] Error:", error)
+    // Non-critical — return a fallback
+    return NextResponse.json({ title: null }, { status: 200 })
+  }
+}

--- a/app/api/respond/route.ts
+++ b/app/api/respond/route.ts
@@ -47,6 +47,7 @@ export async function POST(request: NextRequest) {
 
     const config = getConfigInfo(kind)
     console.log(`[Respond] Using ${kind} mode:`, config)
+    console.log(`[Respond] Input length: ${body.input.length} chars, hasPreviousResponseId: ${!!body.previous_response_id}`)
 
     // Use centralized client for the request
     const response = await createTextResponse({

--- a/app/api/respond/route.ts
+++ b/app/api/respond/route.ts
@@ -12,7 +12,15 @@ export const runtime = "nodejs"
 
 const SYSTEM_INSTRUCTIONS = `You are a helpful, concise assistant. Keep responses brief and focused. Avoid lengthy explanations unless specifically asked for detail. Be direct and practical.
 
-When you receive context about coding tasks you have completed (files created, code generated, etc.), treat that work as your own. Answer questions about it naturally and directly — for example, if asked "what files did you just create?", list the files confidently without referencing any internal process, context injection, or task system. The user should experience a seamless conversation where you are fully aware of the work you did.`
+CRITICAL RULE — Coding task awareness:
+When you receive context about coding tasks (files created, code generated, plans executed, etc.), you MUST treat that work as your own. You wrote that code. You created those files. You know every line. Never say "I don't have the code contents", "I can't see the files", "I can only guess", or anything similar. If the user asks about files, code, or implementation details from a task, answer from the full context you were given — quote specific code, reference exact file contents, and explain implementation decisions. The user expects you to have complete knowledge of the work because you did it.
+
+Rules:
+- NEVER reference "context injection", "task system", "context window", or internal processes
+- NEVER say you "can't see" or "don't have access to" code from tasks you completed
+- ALWAYS answer questions about your completed work with full confidence and specificity
+- If asked "what files did you create?", list them all with descriptions of their contents
+- If asked about specific code, quote the relevant sections directly`
 
 interface RespondRequest {
   input: string

--- a/app/demos/unified/page.tsx
+++ b/app/demos/unified/page.tsx
@@ -36,6 +36,7 @@ import type { CodexTask, WorkspaceSnapshot } from "@/lib/codex/types"
 import type { StoredChatThread, StoredChatThreadMeta } from "@/lib/store/types"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { logAuditClient, flushAuditTelemetry } from "@/lib/telemetry"
+import { SessionChatCache } from "@/lib/session-cache"
 
 // =============================================================================
 // HELPERS
@@ -74,28 +75,40 @@ function extractFindQuery(text: string): string {
 }
 
 /**
- * Build a compact context string from a task's context summary.
- * Written in first person so the model treats it as its own work,
- * keeping the experience seamless for the user.
+ * Build a FULL context string from a completed codex task.
+ *
+ * Includes the complete file contents so the model has the same knowledge
+ * it would have if it had actually written the code. This is a demo-only
+ * approach — in production you'd use a smarter context window strategy.
  */
 function buildTaskContextInput(task: CodexTask): string | null {
   const summary = task.contextSummary
   if (!summary) return null
 
   const lines: string[] = [
-    `I just completed the coding task "${summary.title}". Here is what I did:`,
+    `I just completed the coding task "${summary.title}". Here is exactly what I did:`,
     "",
   ]
 
-  if (summary.bullets.length > 0) {
-    for (const bullet of summary.bullets.slice(0, 4)) {
-      lines.push(`- ${bullet}`)
-    }
+  // Include the implementation plan so the model understands the "why"
+  if (task.planMarkdown) {
+    lines.push("## Implementation Plan")
+    lines.push(task.planMarkdown)
     lines.push("")
   }
 
-  const filePaths = summary.filePaths.slice(0, 10)
-  lines.push(`Files created/modified: ${filePaths.join(", ")}${summary.filePaths.length > 10 ? ` and ${summary.filePaths.length - 10} more` : ""}`)
+  // Include FULL file contents for every changed file
+  if (task.changes.length > 0) {
+    lines.push("## Files Created/Modified")
+    lines.push("")
+    for (const change of task.changes) {
+      lines.push(`### ${change.path}`)
+      lines.push("```")
+      lines.push(change.after)
+      lines.push("```")
+      lines.push("")
+    }
+  }
 
   if (summary.languages.length > 0) {
     lines.push(`Languages used: ${summary.languages.join(", ")}`)
@@ -128,13 +141,40 @@ async function createStoredThread(title?: string): Promise<string | null> {
     })
     if (!res.ok) {
       console.error("[Persist] createStoredThread failed:", res.status)
-      return null
+      // Fallback: create locally in session cache
+      const localThread = {
+        id: generateId(),
+        title: title || "New Chat",
+        category: "recent" as const,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        messages: [],
+      }
+      SessionChatCache.saveThread(localThread)
+      SessionChatCache.trackEvent("localOnlyThreads")
+      return localThread.id
     }
     const data = await res.json()
-    return data.thread?.id ?? null
+    const threadId = data.thread?.id ?? null
+    // Write-through: cache locally for resilience
+    if (data.thread) {
+      SessionChatCache.saveThread(data.thread)
+    }
+    return threadId
   } catch (err) {
     console.error("[Persist] createStoredThread error:", err)
-    return null
+    // Fallback: create locally in session cache
+    const localThread = {
+      id: generateId(),
+      title: title || "New Chat",
+      category: "recent" as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      messages: [],
+    }
+    SessionChatCache.saveThread(localThread)
+    SessionChatCache.trackEvent("localOnlyThreads")
+    return localThread.id
   }
 }
 
@@ -151,6 +191,14 @@ async function persistMessage(
     contextMeta?: { branchId: string; branchTitle: string; mergeType: "summary" | "full" }
   }
 ): Promise<boolean> {
+  // Write-through: always cache locally (immediate, synchronous)
+  SessionChatCache.appendMessage(threadId, {
+    id: message.id,
+    role: message.role as "user" | "assistant" | "context",
+    text: message.text,
+    createdAt: message.createdAt,
+    responseId: message.responseId,
+  })
   try {
     const res = await fetch(`/api/chats/${threadId}/messages`, {
       method: "POST",
@@ -171,6 +219,8 @@ async function updateStoredThread(
   threadId: string,
   updates: { title?: string; summary?: string; lastResponseId?: string | null }
 ): Promise<boolean> {
+  // Write-through: update session cache immediately
+  SessionChatCache.updateThread(threadId, updates)
   try {
     const res = await fetch(`/api/chats/${threadId}`, {
       method: "PATCH",
@@ -290,16 +340,27 @@ function UnifiedDemoContent() {
     }
   }, [])
 
-  // Fetch threads for sidebar
+  // Fetch threads for sidebar, merging with session cache
   const fetchThreads = useCallback(async () => {
     try {
-      const res = await fetch("/api/chats")
-      if (res.ok) {
-        const data = await res.json()
-        setThreads(data.threads || [])
-      } else {
-        console.error("[fetchThreads] API returned:", res.status)
+      let serverThreads: StoredChatThreadMeta[] = []
+      try {
+        const res = await fetch("/api/chats")
+        if (res.ok) {
+          const data = await res.json()
+          serverThreads = data.threads || []
+        }
+      } catch {
+        // Server unreachable — session cache will fill in
       }
+      // Merge with session cache (union by ID, server wins)
+      const localThreads = SessionChatCache.listThreads()
+      const mergedMap = new Map<string, StoredChatThreadMeta>()
+      for (const t of localThreads) mergedMap.set(t.id, t)
+      for (const t of serverThreads) mergedMap.set(t.id, t)
+      const merged = Array.from(mergedMap.values())
+      merged.sort((a, b) => b.updatedAt - a.updatedAt)
+      setThreads(merged)
     } catch (error) {
       console.error("[fetchThreads] Failed:", error)
     } finally {
@@ -532,82 +593,100 @@ function UnifiedDemoContent() {
         return
       }
 
+      // Try server first, then fall back to session cache
+      let thread: StoredChatThread | null = null
+      let source = "server"
+
       try {
         const res = await fetch(`/api/chats/${urlChatId}`)
-        if (!res.ok) {
-          toast.error("Failed to load chat")
-          return
+        if (res.ok) {
+          const data = await res.json()
+          thread = data.thread as StoredChatThread
         }
-
-        const data = await res.json()
-        const thread = data.thread as StoredChatThread
-
-        if (thread) {
-          // Convert stored messages to ChatMessage format, preserving task/context metadata
-          const loadedMessages: UnifiedMessage[] = thread.messages.map((m) => ({
-            localId: m.id,
-            role: m.role as "user" | "assistant" | "context",
-            text: m.text,
-            createdAt: m.createdAt,
-            responseId: m.responseId,
-            ...(m.taskId ? { taskId: m.taskId } : {}),
-            ...(m.isTaskCard ? { isTaskCard: m.isTaskCard } : {}),
-            ...(m.contextMeta ? { contextMeta: m.contextMeta } : {}),
-          }))
-
-          // Restore task objects for any task card messages
-          const taskCardMessages = loadedMessages.filter((m) => m.isTaskCard && m.taskId)
-          for (const msg of taskCardMessages) {
-            if (msg.taskId && !msg.taskId.startsWith("placeholder_")) {
-              try {
-                const taskRes = await fetch(`/api/codex/tasks/${msg.taskId}`)
-                if (taskRes.ok) {
-                  const taskData = await taskRes.json()
-                  setTasks((prev) => ({ ...prev, [msg.taskId!]: taskData.task }))
-                  logAuditClient("5.6", "task_card_restored_on_load", {
-                    taskId: msg.taskId,
-                    taskStatus: taskData.task?.status,
-                    restored: true,
-                  })
-                } else {
-                  logAuditClient("5.6", "task_card_restore_failed", {
-                    taskId: msg.taskId,
-                    status: taskRes.status,
-                  })
-                }
-              } catch {
-                logAuditClient("5.6", "task_card_restore_failed", {
-                  taskId: msg.taskId,
-                  error: "fetch_error",
-                })
-              }
-            }
-          }
-
-          setState({
-            messages: loadedMessages,
-            lastResponseId: thread.lastResponseId || null,
-          })
-          lastResponseIdRef.current = thread.lastResponseId || null
-
-          storedThreadIdRef.current = thread.id
-
-          logAuditClient("5.5", "chat_loaded_from_url", {
-            urlChatId,
-            threadId: thread.id,
-            messageCount: loadedMessages.length,
-            lastResponseId: thread.lastResponseId || null,
-            hasTaskCards: taskCardMessages.length,
-            hasContextMeta: loadedMessages.filter((m) => m.contextMeta).length,
-          })
-
-          // Clear finder state
-          setFinderOptions([])
-        }
-      } catch (error) {
-        console.error("Failed to load chat:", error)
-        toast.error("Failed to load chat")
+      } catch {
+        // Server unreachable — will try session cache
       }
+
+      // Fallback to session cache if server failed
+      if (!thread) {
+        const cached = SessionChatCache.getThread(urlChatId)
+        if (cached) {
+          thread = cached
+          source = "session_cache"
+          SessionChatCache.trackEvent("threadCacheFallbacks")
+        }
+      }
+
+      if (!thread) {
+        // Both sources failed — silently skip (no toast)
+        // The thread may appear later when Redis recovers
+        logAuditClient("5.9", "chat_load_both_failed", {
+          chatId: urlChatId.slice(0, 8),
+        })
+        return
+      }
+
+      // Convert stored messages to ChatMessage format, preserving task/context metadata
+      const loadedMessages: UnifiedMessage[] = thread.messages.map((m) => ({
+        localId: m.id,
+        role: m.role as "user" | "assistant" | "context",
+        text: m.text,
+        createdAt: m.createdAt,
+        responseId: m.responseId,
+        ...(m.taskId ? { taskId: m.taskId } : {}),
+        ...(m.isTaskCard ? { isTaskCard: m.isTaskCard } : {}),
+        ...(m.contextMeta ? { contextMeta: m.contextMeta } : {}),
+      }))
+
+      // Restore task objects for any task card messages
+      const taskCardMessages = loadedMessages.filter((m) => m.isTaskCard && m.taskId)
+      for (const msg of taskCardMessages) {
+        if (msg.taskId && !msg.taskId.startsWith("placeholder_")) {
+          try {
+            const taskRes = await fetch(`/api/codex/tasks/${msg.taskId}`)
+            if (taskRes.ok) {
+              const taskData = await taskRes.json()
+              setTasks((prev) => ({ ...prev, [msg.taskId!]: taskData.task }))
+              logAuditClient("5.6", "task_card_restored_on_load", {
+                taskId: msg.taskId,
+                taskStatus: taskData.task?.status,
+                restored: true,
+              })
+            } else {
+              logAuditClient("5.6", "task_card_restore_failed", {
+                taskId: msg.taskId,
+                status: taskRes.status,
+              })
+            }
+          } catch {
+            logAuditClient("5.6", "task_card_restore_failed", {
+              taskId: msg.taskId,
+              error: "fetch_error",
+            })
+          }
+        }
+      }
+
+      setState({
+        messages: loadedMessages,
+        lastResponseId: thread.lastResponseId || null,
+      })
+      lastResponseIdRef.current = thread.lastResponseId || null
+
+      storedThreadIdRef.current = thread.id
+
+      logAuditClient("5.5", "chat_loaded_from_url", {
+        urlChatId,
+        threadId: thread.id,
+        source,
+        messageCount: loadedMessages.length,
+        lastResponseId: thread.lastResponseId || null,
+        hasTaskCards: taskCardMessages.length,
+        hasContextMeta: loadedMessages.filter((m) => m.contextMeta).length,
+      })
+
+      // Clear finder state
+      setFinderOptions([])
     }
 
     loadChat()
@@ -861,10 +940,21 @@ function UnifiedDemoContent() {
     const currentRequestId = ++requestIdRef.current
 
     try {
+      // Include local session threads as supplementary candidates
+      const localThreads = SessionChatCache.listFullThreads().map((t) => ({
+        id: t.id,
+        title: t.title,
+        summary: t.summary || "",
+        category: t.category,
+        createdAt: t.createdAt,
+        updatedAt: t.updatedAt,
+        messages: t.messages.map((m) => ({ role: m.role, text: m.text })),
+      }))
+
       const res = await fetch("/api/chats/find", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query }),
+        body: JSON.stringify({ query, localThreads }),
       })
 
       if (requestIdRef.current !== currentRequestId) return
@@ -1102,6 +1192,14 @@ function UnifiedDemoContent() {
           durationMs: Date.now() - ingestionStart,
           inputStillDisabled: true, // isLoading is still true here
         })
+
+        // Update thread title with the codex task's generated title
+        if (storedThreadIdRef.current && taskForIngestion.title) {
+          updateStoredThread(storedThreadIdRef.current, {
+            title: `@codex: ${taskForIngestion.title}`,
+          })
+          fetchThreads()
+        }
       }
 
       setIsLoading(false)
@@ -1221,6 +1319,29 @@ function UnifiedDemoContent() {
             lastResponseId: responseData.id,
             summary: summaryText,
           })
+
+          // Auto-generate a clean title after the first exchange (fire-and-forget)
+          if (allMsgs.length <= 2) {
+            fetch("/api/chats/generate-title", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                userMessage: userText.slice(0, 500),
+                assistantMessage: responseData.output_text.slice(0, 500),
+              }),
+            })
+              .then((r) => r.json())
+              .then((data) => {
+                if (data.title) {
+                  updateStoredThread(threadId, { title: data.title })
+                  fetchThreads()
+                }
+              })
+              .catch(() => {
+                // Non-critical — title remains as first-message truncation
+              })
+          }
+
           // Refresh sidebar so the thread shows updated title/time
           fetchThreads()
         }

--- a/lib/codex/store.ts
+++ b/lib/codex/store.ts
@@ -232,8 +232,11 @@ class ResilientCodexStore implements CodexStore {
       return result
     } catch (error) {
       this.markRedisFailure()
-      console.error(`[CodexStore:Resilient] ${operation} Redis failed, using fallback:`,
-        error instanceof Error ? error.message : error)
+      const errMsg = error instanceof Error ? error.message : String(error)
+      const cause = error instanceof Error && error.cause
+        ? ` (cause: ${error.cause instanceof Error ? error.cause.message : String(error.cause)})`
+        : ""
+      console.error(`[CodexStore:Resilient] ${operation} Redis failed, using fallback: ${errMsg}${cause}`)
       return fallbackFn()
     }
   }

--- a/lib/store/store.ts
+++ b/lib/store/store.ts
@@ -478,8 +478,11 @@ class ResilientRedisStore implements ChatStore {
       return result
     } catch (error) {
       this.markRedisFailure()
-      console.error(`[ChatStore:Resilient] ${operation} Redis failed, using fallback:`,
-        error instanceof Error ? error.message : error)
+      const errMsg = error instanceof Error ? error.message : String(error)
+      const cause = error instanceof Error && error.cause
+        ? ` (cause: ${error.cause instanceof Error ? error.cause.message : String(error.cause)})`
+        : ""
+      console.error(`[ChatStore:Resilient] ${operation} Redis failed, using fallback: ${errMsg}${cause}`)
       return fallbackFn()
     }
   }


### PR DESCRIPTION
Three fixes based on user test observations:

1. **Full codex context injection**: Replace compact summary bullets with complete file contents + implementation plan in the context injected after @codex task completion. The model now has full knowledge of every file it "created" and can answer specific questions about code contents. Also strengthens system prompt to never admit lack of context.

2. **Eliminate premature "Failed to load chat" toast**: Add SessionChatCache write-through to the unified page (was missing — only branches page had it). Chat load now falls back to session cache when server returns 404 (caused by Redis down + different serverless instance). Also adds local thread merging to sidebar fetch and /find queries.

3. **Auto-generate chat titles**: New /api/chats/generate-title endpoint uses gpt-5-nano to create a 4-8 word title from the first Q&A exchange. Fires as fire-and-forget after the first response completes. Codex threads also get updated with the task's generated title after ingestion. Sidebar refreshes automatically when title updates arrive.

Root causes identified from test logs:
- Thread 4d117cc5 created at 19:28:22 in Redis → Redis error → fell back to in-memory store → subsequent GET/PATCH from different serverless instance returned 404 (no session cache fallback in unified page)
- Codex ingestion only sent bullet summaries, not full file contents, causing model to honestly say "I can't see the file contents"
- No title generation existed — threads used truncated first message

https://claude.ai/code/session_016ZMdcsFfsLeGQ1p9xf1YnY