### PR TITLE
[codex] Add Assistant demo feature

### DIFF
--- a/app/api/assistant/run/route.ts
+++ b/app/api/assistant/run/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import {
+  createAssistantTaskResult,
+  createFailedAssistantTask,
+  mergeAssistantThreads,
+} from "@/lib/assistant/retrieval"
+import type { AssistantChatThreadInput } from "@/lib/assistant/types"
+import { getChatStore } from "@/lib/store"
+
+export const runtime = "nodejs"
+
+const AssistantMessageSchema = z.object({
+  id: z.string().optional(),
+  role: z.string(),
+  text: z.string(),
+  createdAt: z.number().optional(),
+  taskId: z.string().optional(),
+  isTaskCard: z.boolean().optional(),
+})
+
+const AssistantThreadSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  summary: z.string().optional(),
+  category: z.string().optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  messages: z.array(AssistantMessageSchema).default([]),
+})
+
+const AssistantRunSchema = z.object({
+  request: z.string().min(1),
+  clientTaskId: z.string().optional(),
+  localThreads: z.array(AssistantThreadSchema).optional(),
+  currentThread: AssistantThreadSchema.nullable().optional(),
+  previousTask: z
+    .object({
+      requestText: z.string(),
+      interpretedGoal: z.string(),
+      taskKind: z.string(),
+      resultSummary: z.string(),
+      sources: z.array(z.unknown()),
+    })
+    .nullable()
+    .optional(),
+})
+
+function getDemoUid(request: NextRequest): string | null {
+  return request.cookies.get("demo_uid")?.value ?? null
+}
+
+async function loadStoredThreads(demoUid: string | null): Promise<AssistantChatThreadInput[]> {
+  if (!demoUid) return []
+
+  try {
+    const store = getChatStore()
+    const metas = await store.listThreads(demoUid)
+    const threads: Array<AssistantChatThreadInput | null> = await Promise.all(
+      metas.map(async (meta) => {
+        try {
+          const thread = await store.getThread(demoUid, meta.id)
+          if (!thread) return null
+          const assistantThread: AssistantChatThreadInput = {
+            id: thread.id,
+            title: thread.title,
+            summary: thread.summary,
+            category: thread.category,
+            createdAt: thread.createdAt,
+            updatedAt: thread.updatedAt,
+            messages: thread.messages.map((message) => ({
+              id: message.id,
+              role: message.role,
+              text: message.text,
+              createdAt: message.createdAt,
+              taskId: message.taskId,
+              isTaskCard: message.isTaskCard,
+            })),
+          }
+          return assistantThread
+        } catch {
+          return null
+        }
+      })
+    )
+    return threads.filter((thread): thread is AssistantChatThreadInput => Boolean(thread))
+  } catch (error) {
+    console.error("[POST /api/assistant/run] Failed to load stored threads:", error)
+    return []
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let requestText = ""
+  const fallbackId = crypto.randomUUID()
+
+  try {
+    const body = await request.json()
+    const parsed = AssistantRunSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request body",
+          details: parsed.error.flatten(),
+        },
+        { status: 400 }
+      )
+    }
+
+    requestText = parsed.data.request.trim()
+    const taskId = parsed.data.clientTaskId || fallbackId
+    const storedThreads = await loadStoredThreads(getDemoUid(request))
+    const threads = mergeAssistantThreads(
+      [...(parsed.data.localThreads || []), ...storedThreads],
+      parsed.data.currentThread || null
+    )
+
+    const task = createAssistantTaskResult({
+      id: taskId,
+      request: requestText,
+      threads,
+      previousTask: null,
+    })
+
+    return NextResponse.json({ task })
+  } catch (error) {
+    console.error("[POST /api/assistant/run] Error:", error)
+    const message = error instanceof Error ? error.message : "Assistant failed to run"
+    const task = createFailedAssistantTask({
+      id: fallbackId,
+      request: requestText || "Assistant request",
+      error: message,
+    })
+    return NextResponse.json({ task }, { status: 200 })
+  }
+}

--- a/app/demos/unified/page.tsx
+++ b/app/demos/unified/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import {
-  RotateCcw,
   Loader2,
   Send,
   Search,
@@ -26,6 +25,7 @@ import {
 } from "@/components/chat"
 import type { BranchCloseResult } from "@/components/chat"
 import { TaskCard } from "@/components/codex"
+import { AssistantLauncher, AssistantTaskCard } from "@/components/assistant"
 import { FinderOptionCard, type FinderOption } from "@/components/history"
 import { StorageWarningBanner } from "@/components/ui/storage-warning-banner"
 import type {
@@ -37,9 +37,15 @@ import type {
 } from "@/lib/types"
 import type { CodexTask, WorkspaceSnapshot } from "@/lib/codex/types"
 import type { StoredChatThread, StoredChatThreadMeta } from "@/lib/store/types"
+import type {
+  AssistantChatThreadInput,
+  AssistantRunResponse,
+  AssistantTaskResult,
+} from "@/lib/assistant/types"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { logAuditClient, flushAuditTelemetry } from "@/lib/telemetry"
 import { SessionChatCache } from "@/lib/session-cache"
+import { createAssistantDemoThreads } from "@/lib/assistant/demo-seed"
 
 // =============================================================================
 // HELPERS
@@ -61,6 +67,20 @@ function isCodexCommand(text: string): boolean {
  */
 function extractCodexPrompt(text: string): string {
   return text.trim().slice(7).trim() // Remove "@codex "
+}
+
+/**
+ * Check if a message is an @assistant command
+ */
+function isAssistantCommand(text: string): boolean {
+  return text.trim().toLowerCase().startsWith("@assistant ")
+}
+
+/**
+ * Extract the prompt from an @assistant command
+ */
+function extractAssistantPrompt(text: string): string {
+  return text.trim().slice(11).trim() // Remove "@assistant "
 }
 
 /**
@@ -129,6 +149,10 @@ interface UnifiedMessage extends ChatMessage {
   taskId?: string
   /** Whether this is a task card (renders TaskCard instead of bubble) */
   isTaskCard?: boolean
+  /** Optional Assistant task ID if this is an Assistant card message */
+  assistantTaskId?: string
+  /** Whether this is an Assistant card (renders AssistantTaskCard instead of bubble) */
+  isAssistantTaskCard?: boolean
 }
 
 // =============================================================================
@@ -256,6 +280,39 @@ interface FindResponse {
   }>
 }
 
+function createPendingAssistantTask(id: string, requestText: string): AssistantTaskResult {
+  const now = Date.now()
+  return {
+    id,
+    createdAt: now,
+    updatedAt: now,
+    status: "searching",
+    requestText,
+    interpretedGoal:
+      "Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.",
+    taskKind: "clarification",
+    progress: ["queued", "interpreting", "searching"],
+    sources: [],
+    resultSummary: "Reviewing available chat context...",
+    proposedActions: [],
+    reviewedChatCount: 0,
+  }
+}
+
+function createFailedAssistantTask(
+  id: string,
+  requestText: string,
+  message: string
+): AssistantTaskResult {
+  return {
+    ...createPendingAssistantTask(id, requestText),
+    status: "failed",
+    updatedAt: Date.now(),
+    resultSummary: message,
+    error: message,
+  }
+}
+
 // =============================================================================
 // MAIN COMPONENT
 // =============================================================================
@@ -305,6 +362,11 @@ function UnifiedDemoContent() {
   const [workspace, setWorkspace] = useState<WorkspaceSnapshot | null>(null)
   const ingestedTaskIdsRef = useRef<Set<string>>(new Set())
   const isIngestingRef = useRef(false)
+
+  // ==========================================================================
+  // ASSISTANT STATE
+  // ==========================================================================
+  const [assistantTasks, setAssistantTasks] = useState<Record<string, AssistantTaskResult>>({})
 
   // ==========================================================================
   // FIND STATE
@@ -381,6 +443,103 @@ function UnifiedDemoContent() {
       setIsLoadingThreads(false)
     }
   }, [])
+
+  const buildAssistantLocalThreads = useCallback((): AssistantChatThreadInput[] => {
+    return SessionChatCache.listFullThreads().map((thread) => ({
+      id: thread.id,
+      title: thread.title,
+      summary: thread.summary,
+      category: thread.category,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      messages: thread.messages.map((message) => ({
+        id: message.id,
+        role: message.role,
+        text: message.text,
+        createdAt: message.createdAt,
+        taskId: message.taskId,
+        isTaskCard: message.isTaskCard,
+      })),
+    }))
+  }, [])
+
+  const buildCurrentAssistantThread = useCallback(
+    (messageList: UnifiedMessage[] = state.messages as UnifiedMessage[]): AssistantChatThreadInput | null => {
+      const visibleMessages = messageList.filter(
+        (message) =>
+          !message.isAssistantTaskCard &&
+          !message.text.trim().toLowerCase().startsWith("@assistant ")
+      )
+      if (visibleMessages.length === 0) return null
+
+      const threadId = storedThreadIdRef.current || "current-chat"
+      const threadMeta = threads.find((thread) => thread.id === threadId)
+      const firstCreatedAt = visibleMessages[0]?.createdAt || Date.now()
+
+      return {
+        id: threadId,
+        title: threadMeta?.title || "Current chat",
+        summary: threadMeta?.summary,
+        category: threadMeta?.category || "recent",
+        createdAt: threadMeta?.createdAt || firstCreatedAt,
+        updatedAt: Date.now(),
+        messages: visibleMessages.map((message) => ({
+          id: message.localId,
+          role: message.role,
+          text: message.text,
+          createdAt: message.createdAt,
+          taskId: message.taskId,
+          isTaskCard: message.isTaskCard,
+        })),
+      }
+    },
+    [state.messages, threads]
+  )
+
+  const runAssistantTask = useCallback(
+    async (
+      request: string,
+      options?: {
+        taskId?: string
+        previousTask?: AssistantTaskResult | null
+        currentMessages?: UnifiedMessage[]
+      }
+    ): Promise<AssistantTaskResult> => {
+      const taskId = options?.taskId || generateId()
+      const res = await fetch("/api/assistant/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          request,
+          clientTaskId: taskId,
+          localThreads: buildAssistantLocalThreads(),
+          currentThread: buildCurrentAssistantThread(options?.currentMessages),
+          previousTask: options?.previousTask || null,
+        }),
+      })
+
+      const data = (await res.json()) as AssistantRunResponse | { error?: string }
+      if (!res.ok || !("task" in data)) {
+        const errorMessage = "error" in data ? data.error : undefined
+        throw new Error(errorMessage || "Assistant failed to run")
+      }
+
+      setAssistantTasks((prev) => ({ ...prev, [data.task.id]: data.task }))
+      return data.task
+    },
+    [buildAssistantLocalThreads, buildCurrentAssistantThread]
+  )
+
+  const handleLoadAssistantSampleWorkspace = useCallback(() => {
+    const sampleThreads = createAssistantDemoThreads()
+    for (const thread of sampleThreads) {
+      SessionChatCache.saveThread(thread)
+    }
+    fetchThreads()
+    toast.success("Sample Assistant workspace loaded", {
+      description: "Demo chats were added to this browser session.",
+    })
+  }, [fetchThreads])
 
   const logRespondCall = useCallback(
     (params: {
@@ -944,6 +1103,12 @@ function UnifiedDemoContent() {
       return
     }
 
+    // Check for @assistant command
+    if (isAssistantCommand(userText)) {
+      await handleAssistantCommand(userText)
+      return
+    }
+
     // Check for @codex command
     if (isCodexCommand(userText)) {
       await handleCodexCommand(userText)
@@ -1032,6 +1197,84 @@ function UnifiedDemoContent() {
       toast.error("Failed to open chat")
     } finally {
       setOpeningChatId(null)
+    }
+  }
+
+  // Handle @assistant command
+  const handleAssistantCommand = async (text: string) => {
+    const prompt = extractAssistantPrompt(text)
+    if (!prompt) {
+      toast.error("Please provide a request after @assistant")
+      return
+    }
+
+    const userMessage: UnifiedMessage = {
+      localId: generateId(),
+      role: "user",
+      text,
+      createdAt: Date.now(),
+    }
+
+    const assistantTaskId = generateId()
+    const taskMessage: UnifiedMessage = {
+      localId: generateId(),
+      role: "assistant",
+      text: "Assistant task",
+      createdAt: Date.now(),
+      assistantTaskId,
+      isAssistantTaskCard: true,
+    }
+
+    const nextMessages = [...messages, userMessage, taskMessage]
+    setAssistantTasks((prev) => ({
+      ...prev,
+      [assistantTaskId]: createPendingAssistantTask(assistantTaskId, prompt),
+    }))
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, userMessage, taskMessage],
+    }))
+
+    // Persist the visible command message only. Assistant cards are session-level
+    // demo state and do not mutate existing chat history.
+    if (!storedThreadIdRef.current) {
+      const id = await createStoredThread(`@assistant: ${prompt.slice(0, 30)}...`)
+      if (id) {
+        storedThreadIdRef.current = id
+        selfSetChatIdRef.current = id
+        router.replace(`/demos/unified?chatId=${id}`, { scroll: false })
+        await persistMessage(id, {
+          id: userMessage.localId,
+          role: userMessage.role,
+          text: userMessage.text,
+          createdAt: userMessage.createdAt,
+        })
+        fetchThreads()
+      } else {
+        toast.error("Failed to save chat - storage may be unavailable")
+      }
+    } else {
+      await persistMessage(storedThreadIdRef.current, {
+        id: userMessage.localId,
+        role: userMessage.role,
+        text: userMessage.text,
+        createdAt: userMessage.createdAt,
+      })
+    }
+
+    try {
+      await runAssistantTask(prompt, {
+        taskId: assistantTaskId,
+        currentMessages: nextMessages,
+      })
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Assistant failed to run"
+      setAssistantTasks((prev) => ({
+        ...prev,
+        [assistantTaskId]: createFailedAssistantTask(assistantTaskId, prompt, errorMessage),
+      }))
+      toast.error(errorMessage)
     }
   }
 
@@ -1848,6 +2091,7 @@ function UnifiedDemoContent() {
     setBranchesByParentLocalId({})
     setActiveBranchId(null)
     setTasks({})
+    setAssistantTasks({})
     setFinderOptions([])
     setInputValue("")
     setAttachedFile(null)
@@ -1885,6 +2129,53 @@ function UnifiedDemoContent() {
   const handleSelectThread = (threadId: string) => {
     if (threadId === storedThreadIdRef.current) return
     router.push(`/demos/unified?chatId=${threadId}`)
+  }
+
+  const handleOpenAssistantChat = (chatId: string) => {
+    if (!chatId || chatId === "current-chat") return
+    handleSelectThread(chatId)
+  }
+
+  const handleInsertAssistantPrompt = (prompt: string) => {
+    setInputValue(prompt)
+    toast.success("Prompt inserted")
+  }
+
+  const handleCloseAssistantTask = (taskId: string) => {
+    setState((prev) => ({
+      ...prev,
+      messages: prev.messages.filter(
+        (message) => (message as UnifiedMessage).assistantTaskId !== taskId
+      ),
+    }))
+    setAssistantTasks((prev) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [taskId]: _removed, ...rest } = prev
+      return rest
+    })
+  }
+
+  const handleAssistantFollowUp = async (text: string, parentTaskId: string) => {
+    const previousTask = assistantTasks[parentTaskId] || null
+    setAssistantTasks((prev) => ({
+      ...prev,
+      [parentTaskId]: createPendingAssistantTask(parentTaskId, text),
+    }))
+
+    try {
+      await runAssistantTask(text, {
+        taskId: parentTaskId,
+        previousTask,
+      })
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Assistant failed to run"
+      setAssistantTasks((prev) => ({
+        ...prev,
+        [parentTaskId]: createFailedAssistantTask(parentTaskId, text, errorMessage),
+      }))
+      toast.error(errorMessage)
+    }
   }
 
   // ==========================================================================
@@ -1957,6 +2248,12 @@ function UnifiedDemoContent() {
               <Zap className="h-5 w-5 text-primary" />
               <span className="font-medium">Unified Chat</span>
             </div>
+            <AssistantLauncher
+              onRunTask={runAssistantTask}
+              onLoadSampleWorkspace={handleLoadAssistantSampleWorkspace}
+              onOpenChat={handleOpenAssistantChat}
+              onInsertPrompt={handleInsertAssistantPrompt}
+            />
           </div>
 
           {/* Messages area */}
@@ -1979,6 +2276,10 @@ function UnifiedDemoContent() {
                 <div className="text-xs text-muted-foreground/70 max-w-sm p-3 bg-muted rounded-lg space-y-2">
                   <p>
                     <strong>Features:</strong>
+                  </p>
+                  <p>
+                    <code className="bg-background px-1 rounded">@assistant</code>{" "}
+                    &mdash; Work across chats and recover unfinished work
                   </p>
                   <p>
                     <code className="bg-background px-1 rounded">@codex</code>{" "}
@@ -2006,6 +2307,22 @@ function UnifiedDemoContent() {
               // Messages list
               <div className="p-4 space-y-4">
                 {messages.map((message) => {
+                  // Render AssistantTaskCard for Assistant card messages
+                  if (message.isAssistantTaskCard && message.assistantTaskId) {
+                    const task = assistantTasks[message.assistantTaskId]
+                    if (!task) return null
+                    return (
+                      <AssistantTaskCard
+                        key={`${message.localId}-${message.assistantTaskId}`}
+                        task={task}
+                        onFollowUp={handleAssistantFollowUp}
+                        onClose={() => handleCloseAssistantTask(task.id)}
+                        onOpenChat={handleOpenAssistantChat}
+                        onInsertPrompt={handleInsertAssistantPrompt}
+                      />
+                    )
+                  }
+
                   // Render TaskCard for task messages
                   if (message.isTaskCard && message.taskId) {
                     const task = tasks[message.taskId]
@@ -2132,7 +2449,7 @@ function UnifiedDemoContent() {
                 placeholder={
                   attachedFile
                     ? "Ask about the doc, or say \"read this to me\"..."
-                    : "Type a message, @codex to run a task, or /find to search..."
+                    : "Type a message, @assistant to use Assistant, @codex to run a task, or /find to search..."
                 }
                 disabled={isLoading || isMerging || isGeneratingTTS}
                 rows={1}

--- a/components/assistant/assistant-launcher.tsx
+++ b/components/assistant/assistant-launcher.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useState } from "react"
+import { Compass } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { AssistantPopup } from "@/components/assistant/assistant-popup"
+import type { AssistantTaskResult } from "@/lib/assistant/types"
+
+interface AssistantLauncherProps {
+  onRunTask: (
+    request: string,
+    options?: { taskId?: string; previousTask?: AssistantTaskResult | null }
+  ) => Promise<AssistantTaskResult>
+  onLoadSampleWorkspace: () => void
+  onOpenChat?: (chatId: string) => void
+  onInsertPrompt?: (prompt: string) => void
+}
+
+export function AssistantLauncher({
+  onRunTask,
+  onLoadSampleWorkspace,
+  onOpenChat,
+  onInsertPrompt,
+}: AssistantLauncherProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        variant={isOpen ? "secondary" : "outline"}
+        size="sm"
+        className="gap-1.5"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <Compass className="h-4 w-4" />
+        Assistant
+      </Button>
+      {isOpen && (
+        <AssistantPopup
+          onClose={() => setIsOpen(false)}
+          onRunTask={onRunTask}
+          onLoadSampleWorkspace={onLoadSampleWorkspace}
+          onOpenChat={onOpenChat}
+          onInsertPrompt={onInsertPrompt}
+        />
+      )}
+    </div>
+  )
+}

--- a/components/assistant/assistant-popup.tsx
+++ b/components/assistant/assistant-popup.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { FormEvent, useState } from "react"
+import { Compass, Database, Loader2, Send, X } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { AssistantTaskCard } from "@/components/assistant/assistant-task-card"
+import type { AssistantTaskResult } from "@/lib/assistant/types"
+
+const SUGGESTIONS = [
+  "Find unfinished chats from this week",
+  "Extract lifting numbers into a spreadsheet",
+  "Turn calculus chats into a curriculum",
+  "Find chats that need a Codex follow-up",
+  "Summarize where I left off",
+]
+
+function createPendingTask(id: string, request: string): AssistantTaskResult {
+  const now = Date.now()
+  return {
+    id,
+    createdAt: now,
+    updatedAt: now,
+    status: "searching",
+    requestText: request,
+    interpretedGoal:
+      "Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.",
+    taskKind: "clarification",
+    progress: ["queued", "interpreting", "searching"],
+    sources: [],
+    resultSummary: "Reviewing available chat context...",
+    proposedActions: [],
+    reviewedChatCount: 0,
+  }
+}
+
+interface AssistantPopupProps {
+  onClose: () => void
+  onRunTask: (
+    request: string,
+    options?: { taskId?: string; previousTask?: AssistantTaskResult | null }
+  ) => Promise<AssistantTaskResult>
+  onLoadSampleWorkspace: () => void
+  onOpenChat?: (chatId: string) => void
+  onInsertPrompt?: (prompt: string) => void
+}
+
+export function AssistantPopup({
+  onClose,
+  onRunTask,
+  onLoadSampleWorkspace,
+  onOpenChat,
+  onInsertPrompt,
+}: AssistantPopupProps) {
+  const [input, setInput] = useState("")
+  const [task, setTask] = useState<AssistantTaskResult | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+
+  const runTask = async (request: string) => {
+    const trimmed = request.trim()
+    if (!trimmed || isRunning) return
+
+    const taskId = crypto.randomUUID()
+    setInput("")
+    setTask(createPendingTask(taskId, trimmed))
+    setIsRunning(true)
+
+    try {
+      const result = await onRunTask(trimmed, { taskId, previousTask: task })
+      setTask(result)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Assistant failed to run"
+      toast.error(message)
+      setTask({
+        ...createPendingTask(taskId, trimmed),
+        status: "failed",
+        updatedAt: Date.now(),
+        resultSummary: message,
+        error: message,
+      })
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    runTask(input)
+  }
+
+  return (
+    <div className="absolute right-0 top-full z-40 mt-2 w-[440px] overflow-hidden rounded-xl border border-border bg-card shadow-xl dark:shadow-black/30">
+      <div className="border-b border-border bg-teal-500/5 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-teal-500/10">
+              <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold">Assistant</h2>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.
+              </p>
+            </div>
+          </div>
+          <Button type="button" variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3 p-3">
+        <form onSubmit={handleSubmit} className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="Ask Assistant..."
+            rows={2}
+            disabled={isRunning}
+            className="min-h-[56px] flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-60"
+          />
+          <Button type="submit" size="icon" className="h-10 w-10 shrink-0" disabled={!input.trim() || isRunning}>
+            {isRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          </Button>
+        </form>
+
+        <div className="flex flex-wrap gap-2">
+          {SUGGESTIONS.map((suggestion) => (
+            <Button
+              key={suggestion}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 rounded-full px-2.5 text-[11px]"
+              disabled={isRunning}
+              onClick={() => runTask(suggestion)}
+            >
+              {suggestion}
+            </Button>
+          ))}
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 text-xs"
+          onClick={onLoadSampleWorkspace}
+        >
+          <Database className="h-3.5 w-3.5" />
+          Load sample Assistant workspace
+        </Button>
+
+        <div className="max-h-[560px] overflow-auto">
+          {task ? (
+            <AssistantTaskCard
+              task={task}
+              compact
+              onFollowUp={(text) => runTask(text)}
+              onOpenChat={onOpenChat}
+              onInsertPrompt={onInsertPrompt}
+            />
+          ) : (
+            <div className="rounded-lg border border-dashed border-border px-3 py-8 text-center text-sm text-muted-foreground">
+              Recent Assistant task results will appear here.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/assistant/assistant-task-card.tsx
+++ b/components/assistant/assistant-task-card.tsx
@@ -1,0 +1,535 @@
+"use client"
+
+import { FormEvent, useState } from "react"
+import {
+  AlertCircle,
+  Check,
+  Clipboard,
+  Compass,
+  Download,
+  ExternalLink,
+  FileText,
+  Loader2,
+  MessageSquare,
+  Search,
+  Sparkles,
+  X,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+import { cn } from "@/lib/utils"
+import type {
+  AssistantArtifact,
+  AssistantOpenLoopItem,
+  AssistantProposedAction,
+  AssistantSource,
+  AssistantTaskResult,
+  AssistantTaskStatus,
+} from "@/lib/assistant/types"
+
+const STATUS_LABELS: Record<AssistantTaskStatus, string> = {
+  queued: "Queued",
+  interpreting: "Interpreting",
+  searching: "Reviewing chats",
+  reviewing: "Reviewing context",
+  generating: "Generating",
+  ready: "Ready",
+  failed: "Failed",
+  no_results: "No results",
+}
+
+const STATUS_STYLES: Record<AssistantTaskStatus, string> = {
+  queued: "bg-muted text-muted-foreground",
+  interpreting: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  searching: "bg-teal-500/10 text-teal-700 dark:text-teal-300",
+  reviewing: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  generating: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300",
+  ready: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  failed: "bg-red-500/10 text-red-700 dark:text-red-300",
+  no_results: "bg-muted text-muted-foreground",
+}
+
+interface AssistantTaskCardProps {
+  task: AssistantTaskResult
+  compact?: boolean
+  onFollowUp?: (text: string, parentTaskId: string) => void
+  onClose?: () => void
+  onOpenChat?: (chatId: string) => void
+  onInsertPrompt?: (prompt: string) => void
+}
+
+function downloadArtifact(artifact: AssistantArtifact) {
+  const blob = new Blob([artifact.content], { type: artifact.mimeType })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = artifact.filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+function formatRelativeDate(timestamp?: number): string {
+  if (!timestamp) return ""
+  const diff = Date.now() - timestamp
+  const days = Math.floor(diff / 86400000)
+  if (days <= 0) return "today"
+  if (days === 1) return "1d ago"
+  if (days < 7) return `${days}d ago`
+  return new Date(timestamp).toLocaleDateString()
+}
+
+function copyText(text: string, label = "Copied") {
+  navigator.clipboard.writeText(text)
+  toast.success(label)
+}
+
+function ProgressList({ task }: { task: AssistantTaskResult }) {
+  const steps: Array<{ status: AssistantTaskStatus; label: string }> = [
+    { status: "interpreting", label: "Interpreted request" },
+    { status: "searching", label: "Reviewed available chats" },
+    { status: "reviewing", label: "Checked evidence" },
+    { status: "generating", label: "Prepared result" },
+  ]
+
+  const done = new Set(task.progress)
+  const isRunning = !["ready", "failed", "no_results"].includes(task.status)
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {steps.map((step) => {
+        const complete = done.has(step.status) || task.status === "ready" || task.status === "no_results"
+        return (
+          <div
+            key={step.status}
+            className="flex items-center gap-2 rounded-md border border-border/60 bg-background/60 px-2.5 py-2 text-xs"
+          >
+            {complete ? (
+              <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+            ) : isRunning ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            ) : (
+              <span className="h-3.5 w-3.5 rounded-full border border-border" />
+            )}
+            <span className="truncate">{step.label}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function SourceList({
+  sources,
+  onOpenChat,
+}: {
+  sources: AssistantSource[]
+  onOpenChat?: (chatId: string) => void
+}) {
+  if (sources.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+        No matching chat sources were found.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {sources.slice(0, 5).map((source) => (
+        <div
+          key={`${source.chatId}-${source.title}`}
+          className="rounded-lg border border-border/70 bg-background/60 px-3 py-2.5"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <MessageSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <p className="truncate text-sm font-medium">{source.title}</p>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">{source.reason}</p>
+            </div>
+            {onOpenChat && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 shrink-0 px-2"
+                onClick={() => onOpenChat(source.chatId)}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+          {source.snippet && (
+            <p className="mt-2 rounded-md bg-muted/50 px-2 py-1.5 text-xs leading-relaxed text-muted-foreground">
+              {source.snippet}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ArtifactPanel({ artifact }: { artifact: AssistantArtifact }) {
+  return (
+    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <FileText className="h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-300" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{artifact.filename}</p>
+            <p className="text-xs text-muted-foreground">
+              {artifact.kind.toUpperCase()}
+              {artifact.rowCount ? ` - ${artifact.rowCount} rows` : ""}
+              {artifact.sizeLabel ? ` - ${artifact.sizeLabel}` : ""}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5"
+          onClick={() => downloadArtifact(artifact)}
+        >
+          <Download className="h-3.5 w-3.5" />
+          Download
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function OpenLoopItem({
+  item,
+  onOpenChat,
+  onInsertPrompt,
+}: {
+  item: AssistantOpenLoopItem
+  onOpenChat?: (chatId: string) => void
+  onInsertPrompt?: (prompt: string) => void
+}) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-background/60 px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{item.chatTitle}</p>
+          <p className="text-xs text-muted-foreground">
+            {item.chatId} {item.lastUpdated ? `- ${formatRelativeDate(item.lastUpdated)}` : ""}
+          </p>
+        </div>
+        {onOpenChat && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 px-2"
+            onClick={() => onOpenChat(item.chatId)}
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="mt-2 space-y-2 text-sm">
+        <p>
+          <span className="font-medium">Why unfinished: </span>
+          <span className="text-muted-foreground">{item.reason}</span>
+        </p>
+        <p>
+          <span className="font-medium">Next action: </span>
+          <span className="text-muted-foreground">{item.nextAction}</span>
+        </p>
+      </div>
+      {item.snippet && (
+        <p className="mt-2 rounded-md bg-muted/50 px-2 py-1.5 text-xs leading-relaxed text-muted-foreground">
+          {item.snippet}
+        </p>
+      )}
+      {item.draftCodexPrompt && (
+        <div className="mt-3 rounded-md border border-border bg-muted/30 p-2">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Draft Codex Prompt
+            </p>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2"
+                onClick={() => copyText(item.draftCodexPrompt!, "Codex prompt copied")}
+              >
+                <Clipboard className="h-3.5 w-3.5" />
+              </Button>
+              {onInsertPrompt && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => onInsertPrompt(item.draftCodexPrompt!)}
+                >
+                  Insert
+                </Button>
+              )}
+            </div>
+          </div>
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
+            {item.draftCodexPrompt}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProposedActions({
+  actions,
+  artifact,
+  onOpenChat,
+  onInsertPrompt,
+}: {
+  actions: AssistantProposedAction[]
+  artifact?: AssistantArtifact
+  onOpenChat?: (chatId: string) => void
+  onInsertPrompt?: (prompt: string) => void
+}) {
+  const actionable = actions.filter(
+    (action, index, all) =>
+      index === all.findIndex((candidate) => candidate.type === action.type && candidate.chatId === action.chatId)
+  )
+
+  if (actionable.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actionable.slice(0, 5).map((action) => {
+        if (action.type === "download_artifact" && artifact) {
+          return (
+            <Button
+              key={action.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => downloadArtifact(artifact)}
+            >
+              <Download className="h-3.5 w-3.5" />
+              {action.label}
+            </Button>
+          )
+        }
+        if (action.type === "open_chat" && action.chatId && onOpenChat) {
+          return (
+            <Button
+              key={action.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => onOpenChat(action.chatId!)}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              {action.label}
+            </Button>
+          )
+        }
+        if (action.type === "insert_codex_prompt" && action.prompt && onInsertPrompt) {
+          return (
+            <Button
+              key={action.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => onInsertPrompt(action.prompt!)}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {action.label}
+            </Button>
+          )
+        }
+        return null
+      })}
+    </div>
+  )
+}
+
+export function AssistantTaskCard({
+  task,
+  compact = false,
+  onFollowUp,
+  onClose,
+  onOpenChat,
+  onInsertPrompt,
+}: AssistantTaskCardProps) {
+  const [followUp, setFollowUp] = useState("")
+  const isWorking = !["ready", "failed", "no_results"].includes(task.status)
+
+  const handleFollowUp = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const text = followUp.trim()
+    if (!text || !onFollowUp) return
+    setFollowUp("")
+    onFollowUp(text, task.id)
+  }
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-teal-500/20 bg-card shadow-sm dark:shadow-md dark:shadow-black/20",
+        compact ? "max-h-[560px]" : "w-full"
+      )}
+    >
+      <div className="border-b border-border/70 bg-teal-500/5 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-teal-500/10">
+              <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <p className="font-medium">Assistant</p>
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                    STATUS_STYLES[task.status]
+                  )}
+                >
+                  {STATUS_LABELS[task.status]}
+                </span>
+              </div>
+              <p className="mt-1 break-words text-sm text-muted-foreground">
+                {task.requestText}
+              </p>
+            </div>
+          </div>
+          {onClose && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={onClose}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className={cn("space-y-4 p-4", compact && "max-h-[500px] overflow-auto")}>
+        <div>
+          <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+            Interpreted Goal
+          </p>
+          <p className="text-sm leading-relaxed">{task.interpretedGoal}</p>
+        </div>
+
+        <ProgressList task={task} />
+
+        {isWorking && (
+          <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Working across available chat context...
+          </div>
+        )}
+
+        {task.status === "failed" && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{task.error || task.resultSummary}</span>
+          </div>
+        )}
+
+        <div>
+          <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+            Result
+          </p>
+          <div className="text-sm leading-relaxed">
+            <MarkdownContent content={task.resultSummary} />
+          </div>
+        </div>
+
+        {task.artifact && <ArtifactPanel artifact={task.artifact} />}
+
+        {task.openLoops && task.openLoops.length > 0 && (
+          <div>
+            <p className="mb-2 text-[10px] font-medium uppercase text-muted-foreground">
+              Open Loops Brief
+            </p>
+            <div className="space-y-2">
+              {task.openLoops.map((item) => (
+                <OpenLoopItem
+                  key={item.id}
+                  item={item}
+                  onOpenChat={onOpenChat}
+                  onInsertPrompt={onInsertPrompt}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="mb-2 flex items-center gap-2">
+            <Search className="h-3.5 w-3.5 text-muted-foreground" />
+            <p className="text-[10px] font-medium uppercase text-muted-foreground">
+              Sources Used
+            </p>
+            <span className="text-[10px] text-muted-foreground">
+              {task.reviewedChatCount} reviewed
+            </span>
+          </div>
+          <SourceList sources={task.sources} onOpenChat={onOpenChat} />
+        </div>
+
+        {task.missingInfo && task.missingInfo.length > 0 && (
+          <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+            <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+              Missing or Ambiguous
+            </p>
+            <ul className="space-y-1 text-xs text-muted-foreground">
+              {task.missingInfo.map((item) => (
+                <li key={item}>- {item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <ProposedActions
+          actions={task.proposedActions}
+          artifact={task.artifact}
+          onOpenChat={onOpenChat}
+          onInsertPrompt={onInsertPrompt}
+        />
+
+        {onFollowUp && (
+          <form onSubmit={handleFollowUp} className="flex items-end gap-2 border-t border-border/70 pt-3">
+            <textarea
+              value={followUp}
+              onChange={(event) => setFollowUp(event.target.value)}
+              placeholder="Follow up with Assistant..."
+              rows={1}
+              className="min-h-9 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <Button type="submit" size="sm" disabled={!followUp.trim()}>
+              Send
+            </Button>
+          </form>
+        )}
+
+        {onClose && !compact && (
+          <div className="flex justify-end border-t border-border/70 pt-3">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Resume chat
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/assistant/index.ts
+++ b/components/assistant/index.ts
@@ -1,0 +1,3 @@
+export { AssistantLauncher } from "./assistant-launcher"
+export { AssistantPopup } from "./assistant-popup"
+export { AssistantTaskCard } from "./assistant-task-card"

--- a/lib/assistant/artifacts.ts
+++ b/lib/assistant/artifacts.ts
@@ -1,0 +1,57 @@
+import type { AssistantArtifact, AssistantArtifactKind } from "@/lib/assistant/types"
+
+export function escapeCsvField(value: unknown): string {
+  const raw = value === null || value === undefined ? "" : String(value)
+  if (/[",\n\r]/.test(raw)) {
+    return `"${raw.replace(/"/g, '""')}"`
+  }
+  return raw
+}
+
+export function rowsToCsv<T extends object>(headers: string[], rows: T[]): string {
+  const lines = [
+    headers.map(escapeCsvField).join(","),
+    ...rows.map((row) =>
+      headers.map((header) => escapeCsvField(row[header as keyof T])).join(",")
+    ),
+  ]
+  return lines.join("\n")
+}
+
+export function makeAssistantArtifact(args: {
+  kind: AssistantArtifactKind
+  filename: string
+  content: string
+  rowCount?: number
+}): AssistantArtifact {
+  const mimeTypeByKind: Record<AssistantArtifactKind, string> = {
+    csv: "text/csv;charset=utf-8",
+    markdown: "text/markdown;charset=utf-8",
+    text: "text/plain;charset=utf-8",
+    html: "text/html;charset=utf-8",
+  }
+
+  const byteCount = new TextEncoder().encode(args.content).length
+  const sizeLabel =
+    byteCount < 1024
+      ? `${byteCount} B`
+      : `${Math.round((byteCount / 1024) * 10) / 10} KB`
+
+  return {
+    kind: args.kind,
+    filename: args.filename,
+    mimeType: mimeTypeByKind[args.kind],
+    content: args.content,
+    rowCount: args.rowCount,
+    sizeLabel,
+  }
+}
+
+export function slugifyFilenamePart(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+  return slug || "assistant-output"
+}

--- a/lib/assistant/demo-seed.ts
+++ b/lib/assistant/demo-seed.ts
@@ -1,0 +1,157 @@
+import type { StoredChatThread } from "@/lib/store/types"
+
+function message(id: string, role: "user" | "assistant", text: string, createdAt: number) {
+  return { id, role, text, createdAt }
+}
+
+export function createAssistantDemoThreads(now = Date.now()): StoredChatThread[] {
+  const hour = 60 * 60 * 1000
+  const day = 24 * hour
+
+  return [
+    {
+      id: "assistant-demo-lifting",
+      title: "Lifting numbers and program notes",
+      category: "personal",
+      summary:
+        "Current lifting numbers, target sets, and program notes for squat, bench, deadlift, and overhead press.",
+      createdAt: now - 5 * day,
+      updatedAt: now - 1 * day,
+      lastResponseId: null,
+      messages: [
+        message(
+          "assistant-demo-lifting-1",
+          "user",
+          "Here are my current lifting numbers: squat 315 lb for 5 reps, bench press 225 lb for 3 reps, deadlift 405 lb for 1 rep, overhead press 135 lb for 5 reps. Bodyweight is 184 lb.",
+          now - 5 * day
+        ),
+        message(
+          "assistant-demo-lifting-2",
+          "assistant",
+          "Logged. Your next block can use conservative training maxes and keep the heavy deadlift exposure low.",
+          now - 5 * day + hour
+        ),
+        message(
+          "assistant-demo-lifting-3",
+          "user",
+          "For the next program, use 5x5 squat at 275 lb, bench 5x5 at 195 lb, deadlift 1x5 at 365 lb, and overhead press 5x5 at 115 lb. Add a note that my left shoulder was cranky on bench.",
+          now - 2 * day
+        ),
+        message(
+          "assistant-demo-lifting-4",
+          "assistant",
+          "I would treat the shoulder note as a constraint and keep bench volume steady until it calms down.",
+          now - 2 * day + hour
+        ),
+      ],
+    },
+    {
+      id: "assistant-demo-calculus",
+      title: "Calculus self-study plan",
+      category: "personal",
+      summary:
+        "A learning path covering limits, derivatives, integrals, series, and applications.",
+      createdAt: now - 6 * day,
+      updatedAt: now - 2 * day,
+      lastResponseId: null,
+      messages: [
+        message(
+          "assistant-demo-calculus-1",
+          "user",
+          "I want to relearn calculus from scratch. I remember algebra and trig, but limits and epsilon-delta proofs are rusty.",
+          now - 6 * day
+        ),
+        message(
+          "assistant-demo-calculus-2",
+          "assistant",
+          "Start with functions, graphs, limits, continuity, and only then move into derivative rules.",
+          now - 6 * day + hour
+        ),
+        message(
+          "assistant-demo-calculus-3",
+          "user",
+          "Can you turn this into a curriculum that gets me to integration techniques, Taylor series, and optimization problems?",
+          now - 2 * day
+        ),
+        message(
+          "assistant-demo-calculus-4",
+          "assistant",
+          "Yes. The sequence should be: limits and continuity, derivatives, applications of derivatives, basic integrals, integration techniques, infinite series, Taylor polynomials, and mixed review.",
+          now - 2 * day + hour
+        ),
+      ],
+    },
+    {
+      id: "assistant-demo-codex-plan",
+      title: "Codex follow-up for onboarding bug",
+      category: "coding",
+      summary:
+        "A plan to run Codex on a signup onboarding state bug, but no Codex task was run.",
+      createdAt: now - 4 * day,
+      updatedAt: now - 3 * day,
+      lastResponseId: null,
+      messages: [
+        message(
+          "assistant-demo-codex-plan-1",
+          "user",
+          "The onboarding checklist is not marking the profile step complete after saving the profile form.",
+          now - 4 * day
+        ),
+        message(
+          "assistant-demo-codex-plan-2",
+          "assistant",
+          "The likely fix is in the profile save handler or onboarding progress reducer. Next step: run Codex to inspect the profile form submit path, update completion state after successful save, and add a regression test.",
+          now - 3 * day
+        ),
+      ],
+    },
+    {
+      id: "assistant-demo-debug-open-loop",
+      title: "Branch merge debugging notes",
+      category: "coding",
+      summary:
+        "Debugging notes for a branch merge race condition that ended before implementation.",
+      createdAt: now - 7 * day,
+      updatedAt: now - 5 * day,
+      lastResponseId: null,
+      messages: [
+        message(
+          "assistant-demo-debug-open-loop-1",
+          "user",
+          "We should fix the race where branch context sometimes merges before the new response id is persisted.",
+          now - 7 * day
+        ),
+        message(
+          "assistant-demo-debug-open-loop-2",
+          "assistant",
+          "Plan: queue branch merge ingestion, await persistence, then re-enable input. Do you want me to turn that into an implementation prompt?",
+          now - 5 * day
+        ),
+      ],
+    },
+    {
+      id: "assistant-demo-pm-prep",
+      title: "Product management interview prep",
+      category: "professional",
+      summary:
+        "Study notes for product sense, metrics, execution, and leadership interview practice.",
+      createdAt: now - 8 * day,
+      updatedAt: now - 4 * day,
+      lastResponseId: null,
+      messages: [
+        message(
+          "assistant-demo-pm-prep-1",
+          "user",
+          "Help me organize product management prep around product sense, analytical metrics, execution tradeoffs, and leadership stories.",
+          now - 8 * day
+        ),
+        message(
+          "assistant-demo-pm-prep-2",
+          "assistant",
+          "Use four tracks: product sense cases, metric diagnosis, execution planning, and behavioral stories. Keep a one-page story bank for leadership examples.",
+          now - 4 * day
+        ),
+      ],
+    },
+  ]
+}

--- a/lib/assistant/retrieval.ts
+++ b/lib/assistant/retrieval.ts
@@ -1,0 +1,851 @@
+import { makeAssistantArtifact, rowsToCsv, slugifyFilenamePart } from "@/lib/assistant/artifacts"
+import type {
+  AssistantArtifact,
+  AssistantChatThreadInput,
+  AssistantOpenLoopItem,
+  AssistantProposedAction,
+  AssistantSource,
+  AssistantTaskKind,
+  AssistantTaskResult,
+  AssistantTaskStatus,
+} from "@/lib/assistant/types"
+
+const MAX_THREAD_TEXT = 12000
+const MAX_SNIPPET = 260
+const OPEN_LOOP_LIMIT = 6
+
+interface ScoredThread {
+  thread: AssistantChatThreadInput
+  score: number
+  confidence: number
+  reason: string
+  snippet: string
+}
+
+interface LiftingCsvRow {
+  sourceChatTitle: string
+  sourceChatId: string
+  dateOrTimeframe: string
+  category: string
+  item: string
+  value: string
+  unit: string
+  repsSets: string
+  notes: string
+  confidence: string
+  sourceSnippet: string
+}
+
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "that",
+  "this",
+  "with",
+  "from",
+  "into",
+  "where",
+  "were",
+  "what",
+  "when",
+  "all",
+  "my",
+  "me",
+  "we",
+  "you",
+  "they",
+  "them",
+  "chat",
+  "chats",
+  "assistant",
+  "find",
+  "make",
+  "turn",
+  "create",
+  "give",
+  "need",
+])
+
+const DOMAIN_TERMS: Record<string, string[]> = {
+  lifting: [
+    "lifting",
+    "lift",
+    "squat",
+    "bench",
+    "deadlift",
+    "press",
+    "overhead",
+    "ohp",
+    "program",
+    "sets",
+    "reps",
+    "lb",
+    "lbs",
+    "kg",
+    "bodyweight",
+  ],
+  calculus: [
+    "calculus",
+    "limits",
+    "continuity",
+    "derivatives",
+    "integrals",
+    "integration",
+    "series",
+    "taylor",
+    "optimization",
+    "curriculum",
+  ],
+  codex: ["codex", "@codex", "implementation", "bug", "fix", "repo", "files", "test"],
+  product: [
+    "product",
+    "management",
+    "pm",
+    "interview",
+    "metrics",
+    "execution",
+    "study",
+    "prep",
+    "leadership",
+  ],
+}
+
+const OPEN_LOOP_TERMS = [
+  "todo",
+  "next step",
+  "next steps",
+  "we should",
+  "after this",
+  "come back",
+  "fix later",
+  "run codex",
+  "codex",
+  "@codex",
+  "implementation prompt",
+  "turn that into",
+  "do you want me",
+  "would you like",
+  "plan:",
+  "debug",
+  "bug",
+  "unresolved",
+]
+
+const EXERCISES = [
+  "bench press",
+  "overhead press",
+  "front squat",
+  "barbell row",
+  "deadlift",
+  "bodyweight",
+  "squat",
+  "bench",
+  "press",
+  "row",
+]
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9@]+/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 1 && !STOPWORDS.has(token))
+}
+
+function unique<T>(values: T[]): T[] {
+  return Array.from(new Set(values))
+}
+
+function truncate(text: string, max = MAX_SNIPPET): string {
+  const cleaned = text.replace(/\s+/g, " ").trim()
+  if (cleaned.length <= max) return cleaned
+  return `${cleaned.slice(0, max - 3).trim()}...`
+}
+
+function isAssistantControlMessage(text: string): boolean {
+  return text.trim().toLowerCase().startsWith("@assistant ")
+}
+
+function isAssistantOnlyThread(thread: AssistantChatThreadInput): boolean {
+  const hasSubstantiveMessage = thread.messages.some(
+    (message) =>
+      message.text?.trim() &&
+      !message.isTaskCard &&
+      !isAssistantControlMessage(message.text)
+  )
+  return thread.title.toLowerCase().startsWith("@assistant") && !hasSubstantiveMessage
+}
+
+function transcriptForThread(thread: AssistantChatThreadInput): string {
+  const lines = thread.messages
+    .filter((message) => message.text?.trim() && !isAssistantControlMessage(message.text))
+    .map((message) => `${message.role}: ${message.text}`)
+  return lines.join("\n").slice(0, MAX_THREAD_TEXT)
+}
+
+function requestDomainTokens(request: string): string[] {
+  const lower = request.toLowerCase()
+  const domains = Object.entries(DOMAIN_TERMS)
+    .filter(([name, terms]) => lower.includes(name) || terms.some((term) => lower.includes(term)))
+    .flatMap(([, terms]) => terms)
+  return unique([...tokenize(request), ...domains])
+}
+
+function classifyTaskKind(request: string): AssistantTaskKind {
+  const lower = request.toLowerCase()
+  const asksForOpenLoops =
+    lower.includes("unfinished") ||
+    lower.includes("open loop") ||
+    lower.includes("left off") ||
+    lower.includes("unresolved") ||
+    lower.includes("follow-up") ||
+    lower.includes("follow up") ||
+    lower.includes("come back") ||
+    lower.includes("planned to run codex") ||
+    lower.includes("need a codex")
+
+  if (lower.includes("codex") && (lower.includes("prompt") || lower.includes("follow"))) {
+    return "codex_prompt_draft"
+  }
+
+  if (asksForOpenLoops) {
+    return "open_loops"
+  }
+
+  if (
+    lower.includes("spreadsheet") ||
+    lower.includes("csv") ||
+    lower.includes("extract") ||
+    lower.includes("curriculum") ||
+    lower.includes("study guide") ||
+    lower.includes("brief") ||
+    lower.includes("document")
+  ) {
+    return "cross_chat_artifact"
+  }
+
+  if (lower.includes("this chat")) {
+    return "current_chat_help"
+  }
+
+  return "clarification"
+}
+
+function interpretedGoalFor(kind: AssistantTaskKind, request: string): string {
+  const lower = request.toLowerCase()
+  if (kind === "codex_prompt_draft") {
+    return "Find likely unfinished Codex plans and draft a clean @codex prompt the user can run."
+  }
+  if (kind === "open_loops") {
+    return "Review recent chats for unfinished work, explain why each looks open, and suggest the next action."
+  }
+  if (kind === "cross_chat_artifact" && lower.includes("lifting")) {
+    return "Look across lifting-related chats, extract only stated numbers/program details, and generate a CSV download."
+  }
+  if (kind === "cross_chat_artifact" && lower.includes("curriculum")) {
+    return "Collect relevant learning chats and turn the available context into a downloadable curriculum document."
+  }
+  if (kind === "cross_chat_artifact") {
+    return "Collect relevant chats, organize the available context, and generate a downloadable artifact."
+  }
+  if (kind === "current_chat_help") {
+    return "Use the current chat plus available workspace context to prepare the next product-level action."
+  }
+  return "Interpret the request and review available chat context without mutating existing chats."
+}
+
+function scoreThread(thread: AssistantChatThreadInput, tokens: string[]): ScoredThread {
+  const title = thread.title.toLowerCase()
+  const summary = (thread.summary || "").toLowerCase()
+  const transcript = transcriptForThread(thread).toLowerCase()
+
+  let matchScore = 0
+  const matchedTerms: string[] = []
+  for (const token of tokens) {
+    let matched = false
+    if (title.includes(token)) {
+      matchScore += 5
+      matched = true
+    }
+    if (summary.includes(token)) {
+      matchScore += 3
+      matched = true
+    }
+    const transcriptMatches = transcript.split(token).length - 1
+    if (transcriptMatches > 0) {
+      matchScore += Math.min(transcriptMatches, 6)
+      matched = true
+    }
+    if (matched) matchedTerms.push(token)
+  }
+
+  let score = matchScore
+  const ageMs = Date.now() - thread.updatedAt
+  if (matchScore > 0 && ageMs >= 0 && ageMs < 7 * 24 * 60 * 60 * 1000) {
+    score += 1.5
+  }
+
+  const snippet = findSnippet(thread, tokens)
+  const confidence = Math.max(0.35, Math.min(0.98, score / 18))
+  const reason =
+    matchedTerms.length > 0
+      ? `Matched ${unique(matchedTerms).slice(0, 4).join(", ")} in this chat.`
+      : "Reviewed as part of the available chat workspace."
+
+  return { thread, score, confidence, reason, snippet }
+}
+
+function selectRelevantThreads(
+  request: string,
+  threads: AssistantChatThreadInput[],
+  limit = 8
+): ScoredThread[] {
+  const tokens = requestDomainTokens(request)
+  const scored = threads.map((thread) => scoreThread(thread, tokens))
+  scored.sort((a, b) => b.score - a.score || b.thread.updatedAt - a.thread.updatedAt)
+  return scored.filter((item) => item.score > 0).slice(0, limit)
+}
+
+function findSnippet(thread: AssistantChatThreadInput, tokens: string[]): string {
+  const fragments = thread.messages
+    .filter((message) => message.text)
+    .flatMap((message) => message.text.split(/(?<=[.!?])\s+|\n+/))
+    .map((fragment) => fragment.trim())
+    .filter(Boolean)
+
+  const scored = fragments.map((fragment) => {
+    const lower = fragment.toLowerCase()
+    const score = tokens.reduce((sum, token) => sum + (lower.includes(token) ? 1 : 0), 0)
+    return { fragment, score }
+  })
+
+  scored.sort((a, b) => b.score - a.score)
+  const best = scored.find((item) => item.score > 0) || scored[scored.length - 1]
+  return truncate(best?.fragment || thread.summary || thread.title)
+}
+
+function sourcesFromScored(scored: ScoredThread[]): AssistantSource[] {
+  return scored.map((item) => ({
+    chatId: item.thread.id,
+    title: item.thread.title,
+    updatedAt: item.thread.updatedAt,
+    reason: item.reason,
+    snippet: item.snippet,
+    confidence: item.confidence,
+  }))
+}
+
+function splitIntoExtractionSegments(text: string): string[] {
+  return text
+    .split(/\n+|[.;]\s+|,\s+(?=(?:and\s+)?(?:squat|bench|deadlift|overhead|press|bodyweight|front|row))/i)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+}
+
+function extractExercise(segment: string): string {
+  const lower = segment.toLowerCase()
+  return EXERCISES.find((exercise) => lower.includes(exercise)) || ""
+}
+
+function extractRepsSets(segment: string): string {
+  const setsByReps = segment.match(/\b(\d+)\s*[xX]\s*(\d+)\b/)
+  if (setsByReps) return `${setsByReps[1]}x${setsByReps[2]}`
+
+  const setsOf = segment.match(/\b(\d+)\s+sets?\s+(?:of\s+)?(\d+)\b/i)
+  if (setsOf) return `${setsOf[1]}x${setsOf[2]}`
+
+  const reps = segment.match(/\b(?:for\s+)?(\d+)\s+reps?\b/i)
+  if (reps) return `${reps[1]} reps`
+
+  return ""
+}
+
+function extractTimeframe(segment: string, thread: AssistantChatThreadInput): string {
+  const lower = segment.toLowerCase()
+  if (lower.includes("next block") || lower.includes("next program")) return "next block"
+  if (lower.includes("current")) return "current"
+  if (lower.includes("today")) return "today"
+  if (lower.includes("last week")) return "last week"
+  return thread.updatedAt ? new Date(thread.updatedAt).toLocaleDateString("en-US") : ""
+}
+
+function extractLiftingRows(scored: ScoredThread[]): LiftingCsvRow[] {
+  const rows: LiftingCsvRow[] = []
+  const seen = new Set<string>()
+
+  for (const item of scored) {
+    for (const message of item.thread.messages) {
+      if (!message.text) continue
+      for (const segment of splitIntoExtractionSegments(message.text)) {
+        const exercise = extractExercise(segment)
+        const valueMatch = segment.match(/\b(\d+(?:\.\d+)?)\s*(lb|lbs|pounds|kg|kgs|%)\b/i)
+        if (!exercise || !valueMatch) continue
+
+        const key = `${item.thread.id}:${exercise}:${valueMatch[1]}:${truncate(segment, 120)}`
+        if (seen.has(key)) continue
+        seen.add(key)
+
+        const lower = segment.toLowerCase()
+        const category = lower.includes("program") || lower.includes("5x5") || lower.includes("next block")
+          ? "program"
+          : exercise === "bodyweight"
+            ? "bodyweight"
+            : "current strength"
+
+        rows.push({
+          sourceChatTitle: item.thread.title,
+          sourceChatId: item.thread.id,
+          dateOrTimeframe: extractTimeframe(segment, item.thread),
+          category,
+          item: exercise === "bench" ? "bench press" : exercise,
+          value: valueMatch[1],
+          unit: valueMatch[2].toLowerCase().replace("pounds", "lb").replace("lbs", "lb").replace("kgs", "kg"),
+          repsSets: extractRepsSets(segment),
+          notes: lower.includes("shoulder") ? "shoulder note mentioned" : "",
+          confidence: exercise && valueMatch ? "high" : "medium",
+          sourceSnippet: truncate(segment, 220),
+        })
+      }
+    }
+  }
+
+  return rows
+}
+
+function buildLiftingArtifact(request: string, scored: ScoredThread[]): {
+  artifact?: AssistantArtifact
+  summary: string
+  missingInfo: string[]
+} {
+  const rows = extractLiftingRows(scored)
+  const headers = [
+    "sourceChatTitle",
+    "sourceChatId",
+    "dateOrTimeframe",
+    "category",
+    "item",
+    "value",
+    "unit",
+    "repsSets",
+    "notes",
+    "confidence",
+    "sourceSnippet",
+  ]
+
+  if (rows.length === 0) {
+    return {
+      summary:
+        "I reviewed the available lifting-related chats, but did not find explicit exercise numbers with units to place in a CSV.",
+      missingInfo: ["No explicit exercise values with units were found in the reviewed chats."],
+    }
+  }
+
+  const content = rowsToCsv(headers, rows)
+  const artifact = makeAssistantArtifact({
+    kind: "csv",
+    filename: `${slugifyFilenamePart(request)}.csv`,
+    content,
+    rowCount: rows.length,
+  })
+
+  return {
+    artifact,
+    summary: `I found ${rows.length} stated lifting/program data point${rows.length === 1 ? "" : "s"} and generated a CSV. Unknown fields are left blank rather than inferred.`,
+    missingInfo: rows.some((row) => !row.repsSets)
+      ? ["Some rows did not include reps or sets in the source text."]
+      : [],
+  }
+}
+
+function inferDocumentTitle(request: string): string {
+  const lower = request.toLowerCase()
+  if (lower.includes("calculus")) return "Calculus Curriculum"
+  if (lower.includes("product") || lower.includes("pm ")) return "Product Management Study Guide"
+  if (lower.includes("brief")) return "Assistant Brief"
+  return "Assistant Workspace Document"
+}
+
+function extractTopicBullets(request: string, scored: ScoredThread[]): string[] {
+  const tokens = requestDomainTokens(request)
+  const bullets: string[] = []
+  const seen = new Set<string>()
+
+  for (const item of scored) {
+    for (const message of item.thread.messages) {
+      if (!message.text) continue
+      for (const fragment of message.text.split(/(?<=[.!?])\s+|\n+/)) {
+        const lower = fragment.toLowerCase()
+        if (!tokens.some((token) => lower.includes(token))) continue
+        const bullet = truncate(fragment, 180)
+        if (!seen.has(bullet)) {
+          seen.add(bullet)
+          bullets.push(bullet)
+        }
+      }
+    }
+  }
+
+  return bullets.slice(0, 12)
+}
+
+function buildDocumentArtifact(request: string, scored: ScoredThread[]): {
+  artifact?: AssistantArtifact
+  summary: string
+  missingInfo: string[]
+} {
+  const title = inferDocumentTitle(request)
+  const bullets = extractTopicBullets(request, scored)
+
+  if (scored.length === 0 || bullets.length === 0) {
+    return {
+      summary: "I did not find enough matching chat context to generate a useful document.",
+      missingInfo: ["No relevant source snippets were found in available chats."],
+    }
+  }
+
+  const lower = request.toLowerCase()
+  const sequence =
+    lower.includes("calculus")
+      ? [
+          "Functions, graphs, and prerequisite review",
+          "Limits and continuity",
+          "Derivative rules and interpretation",
+          "Applications of derivatives",
+          "Basic integrals and the fundamental theorem",
+          "Integration techniques",
+          "Infinite series and Taylor polynomials",
+          "Mixed review and applied problems",
+        ]
+      : bullets.map((bullet) => bullet.replace(/^[-*]\s*/, ""))
+
+  const content = [
+    `# ${title}`,
+    "",
+    "## Interpreted Goal",
+    interpretedGoalFor("cross_chat_artifact", request),
+    "",
+    "## Context Extracted",
+    ...bullets.map((bullet) => `- ${bullet}`),
+    "",
+    "## Organized Plan",
+    ...sequence.map((item, index) => `${index + 1}. ${item}`),
+    "",
+    "## Sources Used",
+    ...scored.map((item) => `- ${item.thread.title} (${item.thread.id}): ${item.snippet}`),
+    "",
+    "## Missing or Ambiguous Information",
+    "- Timing, exact workload, and mastery checks should be confirmed by the user.",
+    "- The Assistant used only the provided demo chat context and did not invent outside facts.",
+    "",
+  ].join("\n")
+
+  return {
+    artifact: makeAssistantArtifact({
+      kind: "markdown",
+      filename: `${slugifyFilenamePart(title)}.md`,
+      content,
+    }),
+    summary: `I created a downloadable ${title.toLowerCase()} from ${scored.length} source chat${scored.length === 1 ? "" : "s"}.`,
+    missingInfo: ["Timing and exact scope may need user confirmation."],
+  }
+}
+
+function hasQuestionEnding(text: string): boolean {
+  return /\?\s*$/.test(text.trim()) || /\b(do you want|would you like|should i|can you confirm)\b/i.test(text)
+}
+
+function hasCodexTask(thread: AssistantChatThreadInput): boolean {
+  return thread.messages.some((message) => {
+    const text = message.text.trim().toLowerCase()
+    return Boolean(message.taskId || message.isTaskCard || text.startsWith("@codex "))
+  })
+}
+
+function buildCodexPrompt(thread: AssistantChatThreadInput, reason: string): string {
+  const recent = thread.messages
+    .slice(-4)
+    .map((message) => `${message.role}: ${truncate(message.text, 300)}`)
+    .join("\n")
+
+  return [
+    "@codex",
+    `Use the context from "${thread.title}" to finish the unresolved implementation work.`,
+    "",
+    "Context:",
+    recent,
+    "",
+    "Task:",
+    reason.includes("Codex")
+      ? "Inspect the relevant files, implement the planned fix, and add or update focused regression coverage."
+      : "Turn the plan from this chat into the smallest safe implementation, preserving existing behavior.",
+    "",
+    "Guardrails:",
+    "- Keep the patch narrowly scoped.",
+    "- Preserve existing chat, history, branch, file, and artifact behavior.",
+    "- Report changed files and verification steps.",
+  ].join("\n")
+}
+
+function detectOpenLoop(thread: AssistantChatThreadInput, codexOnly: boolean): AssistantOpenLoopItem | null {
+  const messages = thread.messages.filter(
+    (message) => message.text?.trim() && !isAssistantControlMessage(message.text)
+  )
+  if (messages.length === 0) return null
+
+  const transcript = messages.map((message) => message.text).join("\n").toLowerCase()
+  const last = messages[messages.length - 1]
+  const lastText = last.text || ""
+  const recentText = messages.slice(-3).map((message) => message.text).join("\n")
+  const lowerRecent = recentText.toLowerCase()
+  const codexMentioned = /\bcodex\b|@codex/i.test(transcript)
+  const codexPlannedButNotRun = codexMentioned && !hasCodexTask(thread)
+
+  if (codexOnly && !codexPlannedButNotRun && !codexMentioned) return null
+
+  const reasons: string[] = []
+  let confidence = 0
+
+  if (codexPlannedButNotRun) {
+    reasons.push("The chat discussed running Codex, but no Codex task card appears in the thread.")
+    confidence += 0.42
+  }
+  if (last.role === "assistant" && hasQuestionEnding(lastText)) {
+    reasons.push("The last assistant message asks for a decision or follow-up.")
+    confidence += 0.28
+  }
+  if (last.role === "user") {
+    reasons.push("The last message is a user request with no later assistant response in this thread.")
+    confidence += 0.24
+  }
+  const matchedSignals = OPEN_LOOP_TERMS.filter((term) => lowerRecent.includes(term))
+  if (matchedSignals.length > 0) {
+    reasons.push(`Recent messages include open-loop language: ${matchedSignals.slice(0, 3).join(", ")}.`)
+    confidence += Math.min(0.3, matchedSignals.length * 0.08)
+  }
+
+  if (reasons.length === 0) return null
+
+  const reason = reasons.join(" ")
+  const nextAction = codexPlannedButNotRun
+    ? "Review the plan and run a focused Codex prompt."
+    : last.role === "assistant" && hasQuestionEnding(lastText)
+      ? "Answer the assistant's question or ask the Assistant to draft the next prompt."
+      : "Summarize where the chat stopped and choose the next concrete step."
+
+  return {
+    id: `${thread.id}-open-loop`,
+    chatTitle: thread.title,
+    chatId: thread.id,
+    lastUpdated: thread.updatedAt,
+    reason,
+    nextAction,
+    canAssistantHelp: true,
+    suggestedAction: codexPlannedButNotRun ? "Create Codex prompt" : "Summarize where we left off",
+    draftCodexPrompt: codexPlannedButNotRun ? buildCodexPrompt(thread, reason) : undefined,
+    snippet: truncate(recentText, 320),
+    confidence: Math.min(0.97, Math.max(0.55, confidence)),
+  }
+}
+
+function buildOpenLoopsResult(
+  request: string,
+  threads: AssistantChatThreadInput[],
+  taskKind: AssistantTaskKind
+): {
+  openLoops: AssistantOpenLoopItem[]
+  sources: AssistantSource[]
+  summary: string
+  actions: AssistantProposedAction[]
+} {
+  const lower = request.toLowerCase()
+  const codexOnly = taskKind === "codex_prompt_draft" || (lower.includes("codex") && !lower.includes("anything"))
+  const wantsWeek = lower.includes("week")
+  const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+  const candidates = wantsWeek ? threads.filter((thread) => thread.updatedAt >= oneWeekAgo) : threads
+
+  const openLoops = candidates
+    .map((thread) => detectOpenLoop(thread, codexOnly))
+    .filter((item): item is AssistantOpenLoopItem => Boolean(item))
+    .sort((a, b) => b.confidence - a.confidence || (b.lastUpdated || 0) - (a.lastUpdated || 0))
+    .slice(0, OPEN_LOOP_LIMIT)
+
+  const sources = openLoops.map((item) => ({
+    chatId: item.chatId,
+    title: item.chatTitle,
+    updatedAt: item.lastUpdated,
+    reason: item.reason,
+    snippet: item.snippet || "",
+    confidence: item.confidence,
+  }))
+
+  const actions: AssistantProposedAction[] = []
+  for (const item of openLoops) {
+    actions.push({
+      id: `${item.id}-open`,
+      label: "Open chat",
+      type: "open_chat",
+      chatId: item.chatId,
+    })
+    if (item.draftCodexPrompt) {
+      actions.push({
+        id: `${item.id}-insert-codex`,
+        label: "Insert Codex prompt",
+        type: "insert_codex_prompt",
+        chatId: item.chatId,
+        prompt: item.draftCodexPrompt,
+      })
+    }
+  }
+
+  return {
+    openLoops,
+    sources,
+    summary:
+      openLoops.length === 0
+        ? "I reviewed the available recent chats and did not find a clear unfinished thread."
+        : `I found ${openLoops.length} likely unfinished chat${openLoops.length === 1 ? "" : "s"} and prepared next actions.`,
+    actions,
+  }
+}
+
+export function mergeAssistantThreads(
+  threads: AssistantChatThreadInput[],
+  currentThread?: AssistantChatThreadInput | null
+): AssistantChatThreadInput[] {
+  const map = new Map<string, AssistantChatThreadInput>()
+
+  for (const thread of threads) {
+    if (!thread?.id) continue
+    if (isAssistantOnlyThread(thread)) continue
+    const existing = map.get(thread.id)
+    if (!existing || thread.messages.length >= existing.messages.length) {
+      map.set(thread.id, {
+        ...thread,
+        messages: thread.messages || [],
+      })
+    }
+  }
+
+  if (currentThread && currentThread.messages.length > 0) {
+    const existing = map.get(currentThread.id)
+    map.set(currentThread.id, {
+      ...(existing || currentThread),
+      ...currentThread,
+      title: currentThread.title || existing?.title || "Current chat",
+      messages: currentThread.messages,
+      updatedAt: Math.max(currentThread.updatedAt, existing?.updatedAt || 0),
+    })
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+export function createAssistantTaskResult(args: {
+  id: string
+  request: string
+  threads: AssistantChatThreadInput[]
+  previousTask?: {
+    requestText: string
+    interpretedGoal: string
+    taskKind: AssistantTaskKind
+    resultSummary: string
+    sources: AssistantSource[]
+  } | null
+}): AssistantTaskResult {
+  const now = Date.now()
+  const taskKind = classifyTaskKind(args.request)
+  const interpretedGoal = interpretedGoalFor(taskKind, args.request)
+  const progress: AssistantTaskStatus[] = ["queued", "interpreting", "searching", "reviewing"]
+
+  if (taskKind === "open_loops" || taskKind === "codex_prompt_draft") {
+    const result = buildOpenLoopsResult(args.request, args.threads, taskKind)
+    return {
+      id: args.id,
+      createdAt: now,
+      updatedAt: now,
+      status: result.openLoops.length > 0 ? "ready" : "no_results",
+      requestText: args.request,
+      interpretedGoal,
+      taskKind,
+      progress: [...progress, "ready"],
+      sources: result.sources,
+      resultSummary: result.summary,
+      openLoops: result.openLoops,
+      proposedActions: result.actions,
+      missingInfo:
+        result.openLoops.length === 0
+          ? ["No clear unfinished chats matched the requested scope."]
+          : undefined,
+      reviewedChatCount: args.threads.length,
+    }
+  }
+
+  const scored = selectRelevantThreads(args.request, args.threads)
+  const sources = sourcesFromScored(scored)
+  const lower = args.request.toLowerCase()
+  const artifactResult =
+    lower.includes("lifting") || lower.includes("spreadsheet") || lower.includes("csv")
+      ? buildLiftingArtifact(args.request, scored)
+      : buildDocumentArtifact(args.request, scored)
+
+  const proposedActions: AssistantProposedAction[] = []
+  if (artifactResult.artifact) {
+    proposedActions.push({
+      id: `${args.id}-download`,
+      label: "Download artifact",
+      type: "download_artifact",
+    })
+  }
+  for (const source of sources.slice(0, 3)) {
+    proposedActions.push({
+      id: `${args.id}-open-${source.chatId}`,
+      label: "Open chat",
+      type: "open_chat",
+      chatId: source.chatId,
+    })
+  }
+
+  const noResults = !artifactResult.artifact && sources.length === 0
+
+  return {
+    id: args.id,
+    createdAt: now,
+    updatedAt: now,
+    status: noResults ? "no_results" : "ready",
+    requestText: args.request,
+    interpretedGoal,
+    taskKind,
+    progress: [...progress, artifactResult.artifact ? "generating" : "ready", "ready"],
+    sources,
+    resultSummary: artifactResult.summary,
+    artifact: artifactResult.artifact,
+    proposedActions,
+    missingInfo: artifactResult.missingInfo.length > 0 ? artifactResult.missingInfo : undefined,
+    reviewedChatCount: args.threads.length,
+  }
+}
+
+export function createFailedAssistantTask(args: {
+  id: string
+  request: string
+  error: string
+}): AssistantTaskResult {
+  const now = Date.now()
+  return {
+    id: args.id,
+    createdAt: now,
+    updatedAt: now,
+    status: "failed",
+    requestText: args.request,
+    interpretedGoal: "The Assistant could not complete this request.",
+    taskKind: "clarification",
+    progress: ["queued", "interpreting", "failed"],
+    sources: [],
+    resultSummary: args.error,
+    proposedActions: [],
+    missingInfo: [args.error],
+    reviewedChatCount: 0,
+    error: args.error,
+  }
+}

--- a/lib/assistant/types.ts
+++ b/lib/assistant/types.ts
@@ -1,0 +1,120 @@
+import type { StoredChatCategory } from "@/lib/store/types"
+
+export type AssistantTaskStatus =
+  | "queued"
+  | "interpreting"
+  | "searching"
+  | "reviewing"
+  | "generating"
+  | "ready"
+  | "failed"
+  | "no_results"
+
+export type AssistantTaskKind =
+  | "cross_chat_artifact"
+  | "open_loops"
+  | "current_chat_help"
+  | "codex_prompt_draft"
+  | "clarification"
+
+export type AssistantArtifactKind = "csv" | "markdown" | "text" | "html"
+
+export interface AssistantSource {
+  chatId: string
+  title: string
+  updatedAt?: number
+  reason: string
+  snippet: string
+  confidence?: number
+}
+
+export interface AssistantArtifact {
+  kind: AssistantArtifactKind
+  filename: string
+  mimeType: string
+  content: string
+  rowCount?: number
+  sizeLabel?: string
+}
+
+export interface AssistantProposedAction {
+  id: string
+  label: string
+  type:
+    | "open_chat"
+    | "summarize_left_off"
+    | "draft_prompt"
+    | "copy_codex_prompt"
+    | "insert_codex_prompt"
+    | "download_artifact"
+    | "dismiss"
+  chatId?: string
+  prompt?: string
+}
+
+export interface AssistantOpenLoopItem {
+  id: string
+  chatTitle: string
+  chatId: string
+  lastUpdated?: number
+  reason: string
+  nextAction: string
+  canAssistantHelp: boolean
+  suggestedAction: string
+  draftCodexPrompt?: string
+  snippet?: string
+  confidence: number
+}
+
+export interface AssistantTaskResult {
+  id: string
+  createdAt: number
+  updatedAt: number
+  status: AssistantTaskStatus
+  requestText: string
+  interpretedGoal: string
+  taskKind: AssistantTaskKind
+  progress: AssistantTaskStatus[]
+  sources: AssistantSource[]
+  resultSummary: string
+  artifact?: AssistantArtifact
+  openLoops?: AssistantOpenLoopItem[]
+  proposedActions: AssistantProposedAction[]
+  missingInfo?: string[]
+  reviewedChatCount: number
+  error?: string
+}
+
+export interface AssistantChatMessageInput {
+  id?: string
+  role: string
+  text: string
+  createdAt?: number
+  taskId?: string
+  isTaskCard?: boolean
+}
+
+export interface AssistantChatThreadInput {
+  id: string
+  title: string
+  summary?: string
+  category?: StoredChatCategory | string
+  createdAt: number
+  updatedAt: number
+  messages: AssistantChatMessageInput[]
+}
+
+export interface AssistantRunRequest {
+  request: string
+  clientTaskId?: string
+  localThreads?: AssistantChatThreadInput[]
+  currentThread?: AssistantChatThreadInput | null
+  previousTask?: Pick<
+    AssistantTaskResult,
+    "requestText" | "interpretedGoal" | "taskKind" | "resultSummary" | "sources"
+  > | null
+}
+
+export interface AssistantRunResponse {
+  task: AssistantTaskResult
+}


### PR DESCRIPTION
## Summary
- Add a product-level Assistant surface to unified chat with a compact popup and inline `@assistant` task cards.
- Add a demo-scoped `/api/assistant/run` route plus Assistant retrieval, open-loop detection, artifact generation, and sample workspace helpers.
- Support CSV extraction for lifting data, Markdown document artifacts, open-loop briefs, and Codex prompt drafting without mutating existing chats or external systems.

## Validation
- `npm_config_cache=/tmp/npm-cache npx tsc --noEmit`
- `npm_config_cache=/tmp/npm-cache npm run lint` (passes with existing warnings)
- `npm_config_cache=/tmp/npm-cache npm run build`
- Browser verification on `http://localhost:3001/demos/unified`: Assistant popup opens, sample workspace loads, CSV artifact appears, inline `@assistant` renders Open Loops Brief and Codex prompt draft, no console errors.