### PR TITLE
[codex] Harden Assistant demo experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ OPENAI_API_KEY=
 # The centralized OpenAI client (lib/openai/client.ts) uses different models
 # for different request types. Each has sensible defaults but can be overridden.
 #
-# IMPORTANT: GPT-5 series models do NOT support reasoning.effort: "none"
-# The minimum is "low". The client handles this automatically.
+# Reasoning effort values are model-dependent. Supported env values are:
+# none, minimal, low, medium, high, xhigh. The client retries configured
+# fallbacks for summary and Assistant requests when a model rejects a value.
 #
 # IMPORTANT: Chat kinds (fast/deep) use the SAME underlying model to ensure
 # previous_response_id chaining works. Fast vs Deep is controlled via
@@ -37,6 +38,7 @@ OPENAI_MODEL_DEEP=gpt-5-mini
 # Alias: OPENAI_SUMMARY_MODEL (takes priority if set)
 OPENAI_SUMMARY_MODEL=gpt-5-nano
 # OPENAI_MODEL_SUMMARIZE=gpt-5-nano  # Alternative name (lower priority)
+# OPENAI_REASONING_SUMMARIZE=low      # Optional if your summary model rejects "minimal"
 
 # Intent classification (detecting chat-retrieval requests)
 # Default: gpt-5-nano | Reasoning: low | Verbosity: low
@@ -49,6 +51,13 @@ OPENAI_MODEL_STACKS=gpt-5-nano
 # Chat finder/reranking
 # Default: gpt-5-mini | Reasoning: low | Verbosity: low
 OPENAI_MODEL_FINDER=gpt-5-mini
+
+# Assistant workspace tasks (cross-chat briefs, artifacts, open-loop recovery)
+# Default: gpt-5-mini | Reasoning: low | Verbosity: high
+# Raise these for a higher-quality demo run, e.g. reasoning=high or xhigh
+OPENAI_MODEL_ASSISTANT=gpt-5-mini
+OPENAI_ASSISTANT_REASONING=low
+OPENAI_ASSISTANT_VERBOSITY=high
 
 # Codex tasks (code generation)
 # Default: gpt-5.1-codex-mini | Reasoning: medium | Verbosity: medium
@@ -110,3 +119,11 @@ KV_REST_API_TOKEN=
 
 # Note: You only need to set ONE pair of env vars. The app will detect
 # whichever is available (Upstash pattern checked first).
+
+# =============================================================================
+# Vercel Cron / Redis Heartbeat
+# =============================================================================
+# Required for the daily Redis heartbeat cron at /api/internal/redis-heartbeat.
+# Vercel sends this automatically as Authorization: Bearer <CRON_SECRET>.
+# Use a random 16+ character value and configure it in Production env vars.
+CRON_SECRET=

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm run dev
 
 ### Model Configuration
 
-The app uses different models for different request types (chat, summarization, intent classification, code generation, etc.). Defaults are `gpt-5-mini` for chat and search, `gpt-5-nano` for lightweight tasks like summarization and classification, and `gpt-5.1-codex-mini` for code generation. All 8 model overrides are configurable via environment variables -- see [`.env.example`](.env.example) for the complete reference with defaults and explanations.
+The app uses different models for different request types (chat, summarization, intent classification, Assistant artifact generation, code generation, etc.). Defaults are `gpt-5-mini` for chat/search/Assistant, `gpt-5-nano` for lightweight tasks like summarization and classification, and `gpt-5.1-codex-mini` for code generation. Assistant quality can be tuned independently with `OPENAI_MODEL_ASSISTANT`, `OPENAI_ASSISTANT_REASONING`, and `OPENAI_ASSISTANT_VERBOSITY`. See [`.env.example`](.env.example) for the complete reference with defaults and explanations.
 
 ### Storage
 
@@ -68,7 +68,10 @@ You only need one pair. The app detects whichever is available (Upstash checked 
 - **TTL:** All data expires after 7 days to prevent unbounded growth
 - **Namespacing:** Keys are prefixed with user ID (`u:{demo_uid}:...`)
 - **Identity:** Users are identified by a `demo_uid` cookie (no accounts needed)
-- **Status endpoint:** `GET /api/storage` returns current storage status
+- **Status endpoint:** `GET /api/storage` returns current storage status and pings Redis when configured
+- **Heartbeat:** Vercel Cron calls `GET /api/internal/redis-heartbeat` once per day and performs a single Redis `SET` to keep free/low-traffic demo databases active
+
+If a Vercel/Upstash database has been archived or uninstalled due to inactivity, follow [Database Recovery and Heartbeat Setup](docs/database-recovery.md).
 
 ## API Routes
 
@@ -117,6 +120,8 @@ You only need one pair. The app detects whichever is available (Upstash checked 
 | Method | Route | Description |
 |--------|-------|-------------|
 | GET | `/api/storage` | Storage status (type, configured, warnings) |
+| GET | `/api/health` | Redis connectivity diagnostics |
+| GET | `/api/internal/redis-heartbeat` | Protected Vercel Cron endpoint that writes a daily heartbeat key |
 
 ## Demo Scripts
 

--- a/app/api/assistant/run/route.ts
+++ b/app/api/assistant/run/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
       parsed.data.currentThread || null
     )
 
-    const task = createAssistantTaskResult({
+    const task = await createAssistantTaskResult({
       id: taskId,
       request: requestText,
       threads,

--- a/app/api/chats/[id]/summary/route.ts
+++ b/app/api/chats/[id]/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getChatStore } from "@/lib/store"
 import {
-  createTextResponse,
+  createSummarizeResponse,
   extractTextOutput,
   formatOpenAIError,
   getConfigInfo,
@@ -33,6 +33,22 @@ function buildTranscriptForSummary(
       return `${role}: ${text}`
     })
     .join("\n")
+}
+
+function buildFallbackSummary(messages: Array<{ role: string; text: string }>): string {
+  const substantive = messages
+    .filter((message) => message.text?.trim())
+    .slice(-6)
+    .map((message) => {
+      const text = message.text.replace(/\s+/g, " ").trim()
+      return `${message.role === "user" ? "User" : "Assistant"}: ${text.slice(0, 160)}`
+    })
+
+  if (substantive.length === 0) {
+    return "No messages in this conversation."
+  }
+
+  return substantive.join(" | ").slice(0, 360)
 }
 
 /**
@@ -102,17 +118,21 @@ Summary:`
       `[Summary] Generating summary for chat ${id} with model ${config.model}`
     )
 
-    const response = await createTextResponse({
-      kind: "summarize",
-      input: prompt,
-    })
-
-    // Extract summary from response
-    let summary = extractTextOutput(response).trim()
+    let summary = ""
+    try {
+      const { response } = await createSummarizeResponse({
+        input: prompt,
+        instructions: "You are a concise chat summarizer. Output only the summary text.",
+      })
+      summary = extractTextOutput(response).trim()
+    } catch (error) {
+      console.error("[Summary] Model summary failed, using fallback:", error)
+      summary = buildFallbackSummary(thread.messages)
+    }
 
     if (!summary) {
       console.warn("[Summary] Empty summary generated, using fallback")
-      summary = "Summary unavailable."
+      summary = buildFallbackSummary(thread.messages)
     }
 
     // Save summary back to thread

--- a/app/api/chats/generate-title/route.ts
+++ b/app/api/chats/generate-title/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createTextResponse, extractTextOutput, getConfigInfo } from "@/lib/openai"
+import { createSummarizeResponse, extractTextOutput, getConfigInfo } from "@/lib/openai"
 
 export const runtime = "nodejs"
 
@@ -10,7 +10,38 @@ interface GenerateTitleRequest {
   assistantMessage: string
 }
 
+function deriveFallbackTitle(userMessage: string): string {
+  const cleaned = userMessage
+    .replace(/^@\w+\s+/i, "")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!cleaned) return "New Chat"
+
+  const firstThought = cleaned.split(/[.!?\n]/)[0]?.trim() || cleaned
+  const words = firstThought.split(/\s+/).slice(0, 8)
+  const title = words.join(" ").replace(/[:;,]+$/g, "").trim()
+  if (!title) return "New Chat"
+  return title.charAt(0).toUpperCase() + title.slice(1)
+}
+
+function cleanGeneratedTitle(title: string, fallback: string): string {
+  const cleaned = title
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/g, "")
+    .slice(0, 80)
+    .trim()
+
+  if (!cleaned || cleaned.toLowerCase() === "new chat") {
+    return fallback
+  }
+  return cleaned
+}
+
 export async function POST(request: NextRequest) {
+  let fallbackTitle = "New Chat"
+
   try {
     const body = (await request.json()) as GenerateTitleRequest
 
@@ -21,6 +52,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    fallbackTitle = deriveFallbackTitle(body.userMessage)
     const transcript = `User: ${body.userMessage}\nAssistant: ${body.assistantMessage}`
     const prompt = `${TITLE_PROMPT}\n\n${transcript}`
 
@@ -30,19 +62,18 @@ export async function POST(request: NextRequest) {
       console.log(`[GenerateTitle] Using model: ${config.model}`)
     }
 
-    const response = await createTextResponse({
-      kind: "summarize",
+    const { response } = await createSummarizeResponse({
       input: [{ role: "user", content: prompt }],
       instructions: "You are a chat title generator. Output only the title, nothing else.",
-      storeOverride: false,
     })
 
-    const title = extractTextOutput(response).trim().replace(/^["']|["']$/g, "")
+    const title = cleanGeneratedTitle(extractTextOutput(response), fallbackTitle)
 
     return NextResponse.json({ title })
   } catch (error) {
     console.error("[GenerateTitle] Error:", error)
-    // Non-critical — return a fallback
-    return NextResponse.json({ title: null }, { status: 200 })
+    // Non-critical: return a deterministic title so the sidebar does not get stuck
+    // on "New Chat" when the title model or Redis path is degraded.
+    return NextResponse.json({ title: fallbackTitle }, { status: 200 })
   }
 }

--- a/app/api/internal/redis-heartbeat/route.ts
+++ b/app/api/internal/redis-heartbeat/route.ts
@@ -14,6 +14,7 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@vercel/kv"
 
+export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 const HEARTBEAT_KEY = "__system:redis_heartbeat"
@@ -67,7 +68,13 @@ export async function GET(request: Request): Promise<NextResponse> {
       `[redis-heartbeat] OK key=${HEARTBEAT_KEY} ranAt=${ranAt}`
     )
 
-    return NextResponse.json({ ok: true, key: HEARTBEAT_KEY, ranAt })
+    return NextResponse.json({
+      ok: true,
+      key: HEARTBEAT_KEY,
+      command: "SET",
+      ttlSeconds: TTL_SECONDS,
+      ranAt,
+    })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.error(`[redis-heartbeat] FAIL error=${message}`)

--- a/app/api/storage/route.ts
+++ b/app/api/storage/route.ts
@@ -1,5 +1,53 @@
 import { NextResponse } from "next/server"
 import { getStorageInfo } from "@/lib/store"
+import { getRedisClient } from "@/lib/store/redis-client"
+
+const STORAGE_PING_TIMEOUT_MS = 1500
+
+async function checkRedisConnectivity(): Promise<{
+  healthy: boolean
+  connectivity: "ok" | "error" | "timeout" | "not_configured"
+  latencyMs?: number
+  error?: string
+}> {
+  const client = getRedisClient()
+  if (!client) {
+    return { healthy: false, connectivity: "not_configured" }
+  }
+
+  const startedAt = Date.now()
+  const ping = client
+    .ping()
+    .then(() => ({
+      healthy: true,
+      connectivity: "ok" as const,
+      latencyMs: Date.now() - startedAt,
+    }))
+    .catch((error: unknown) => ({
+      healthy: false,
+      connectivity: "error" as const,
+      latencyMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    }))
+
+  const timeout = new Promise<{
+    healthy: false
+    connectivity: "timeout"
+    latencyMs: number
+    error: string
+  }>((resolve) => {
+    setTimeout(() => {
+      resolve({
+        healthy: false,
+        connectivity: "timeout",
+        latencyMs: Date.now() - startedAt,
+        error: "Redis health check timed out",
+      })
+    }, STORAGE_PING_TIMEOUT_MS)
+  })
+
+  return Promise.race([ping, timeout])
+}
 
 /**
  * GET /api/storage - Get current storage status
@@ -15,7 +63,22 @@ import { getStorageInfo } from "@/lib/store"
 export async function GET() {
   try {
     const info = getStorageInfo()
-    return NextResponse.json(info)
+    if (!info.kvConfigured) {
+      return NextResponse.json({
+        ...info,
+        healthy: false,
+        connectivity: "not_configured",
+      })
+    }
+
+    const health = await checkRedisConnectivity()
+    return NextResponse.json({
+      ...info,
+      ...health,
+      warning: health.healthy
+        ? info.warning
+        : `Redis is configured but not reachable (${health.error || health.connectivity}). The demo will use its session fallback until the database is restored or replaced.`,
+    })
   } catch (error) {
     console.error("[GET /api/storage] Error:", error)
     return NextResponse.json(
@@ -24,6 +87,8 @@ export async function GET() {
         kvConfigured: false,
         mode: "memory",
         backend: "memory",
+        healthy: false,
+        connectivity: "error",
         detectedEnvKeys: [],
         warning:
           error instanceof Error ? error.message : "Failed to get storage info",

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -60,6 +60,8 @@ interface StorageInfo {
 interface StorageApiResponse {
   storageType?: "kv" | "memory"
   kvConfigured?: boolean
+  healthy?: boolean
+  connectivity?: "ok" | "error" | "timeout" | "not_configured"
   warning?: string
 }
 
@@ -68,19 +70,25 @@ interface StorageApiResponse {
  */
 function parseStorageResponse(data: StorageApiResponse): StorageInfo {
   const storageType = data?.storageType
-  const type: StorageInfo["type"] =
-    storageType === "kv" || storageType === "memory" ? storageType : "error"
+  const configuredButUnhealthy = data?.kvConfigured && data?.healthy === false
+  const type: StorageInfo["type"] = configuredButUnhealthy
+    ? "error"
+    : storageType === "kv" || storageType === "memory"
+      ? storageType
+      : "error"
 
   return {
     type,
-    available: data?.kvConfigured ?? false,
+    available: Boolean(data?.kvConfigured && data?.healthy !== false),
     message:
       data?.warning ??
       (type === "kv"
-        ? "Using Vercel KV for persistent storage."
+        ? "Using Redis/KV for persistent storage."
         : type === "memory"
           ? "Using in-memory store. Data may reset."
-          : "Unable to determine storage status."),
+          : data?.connectivity
+            ? `Storage check failed: ${data.connectivity}.`
+            : "Unable to determine storage status."),
   }
 }
 

--- a/components/ui/storage-warning-banner.tsx
+++ b/components/ui/storage-warning-banner.tsx
@@ -9,6 +9,8 @@ interface StorageStatus {
   kvConfigured: boolean
   mode?: "redis" | "memory"
   backend?: "upstash" | "vercel_kv" | "memory"
+  healthy?: boolean
+  connectivity?: "ok" | "error" | "timeout" | "not_configured"
   warning?: string
 }
 
@@ -21,7 +23,7 @@ interface StorageWarningBannerProps {
  * in memory mode (without Redis configured).
  *
  * Fetches /api/storage on mount and shows a dismissible warning if
- * mode !== "redis".
+ * mode !== "redis", or Redis is configured but the health check fails.
  */
 export function StorageWarningBanner({ className }: StorageWarningBannerProps) {
   const [status, setStatus] = useState<StorageStatus | null>(null)
@@ -50,8 +52,12 @@ export function StorageWarningBanner({ className }: StorageWarningBannerProps) {
     return null
   }
 
-  // Don't show if Redis is configured (check both old and new fields for compatibility)
-  if (!status || status.mode === "redis" || status.storageType === "kv") {
+  // Don't show if Redis is configured and reachable.
+  const storageLooksHealthy =
+    (status?.mode === "redis" || status?.storageType === "kv") &&
+    status?.healthy !== false
+
+  if (!status || storageLooksHealthy) {
     return null
   }
 

--- a/docs/database-recovery.md
+++ b/docs/database-recovery.md
@@ -1,0 +1,85 @@
+# Database Recovery and Heartbeat Setup
+
+This demo uses Redis for persisted chat history, Codex task state, and workspace snapshots. If the Vercel dashboard says the Upstash database was archived or uninstalled due to inactivity, the app may still show stale `KV` env vars while Redis calls fail at runtime.
+
+Upstash documents that inactive free Redis databases can be archived after a minimum of 14 days, and Pay As You Go databases after a minimum of 3 months. The daily heartbeat below is intentionally one low-cost Redis write per day.
+
+## Restore or Replace Redis
+
+1. Open the Vercel project dashboard for `improved-llm-chat-demo`.
+2. Go to Storage.
+3. If Vercel shows the old Upstash resource as archived/uninstalled, do not keep using its old env vars.
+4. Create or connect a new Upstash Redis database from the Vercel Storage or Marketplace flow.
+5. Use the Free plan for the demo unless you want longer inactivity windows. Choose a region near the Vercel deployment region when possible.
+6. Connect the new Redis database to the project and enable the environment variables for Production.
+7. Confirm the project has one supported REST env pair:
+   - Preferred Upstash names: `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`
+   - Vercel KV names: `KV_REST_API_URL` and `KV_REST_API_TOKEN`
+8. Remove or replace stale values that point at the archived host.
+9. Do not use `REDIS_URL` or `KV_URL` for this app path. Those are native Redis connection strings; this app uses the HTTPS REST endpoint through `@vercel/kv`.
+10. Add `CRON_SECRET` to Production env vars. Use a random value with at least 16 characters.
+11. Redeploy the Production deployment so the new env vars and cron config are active.
+
+## Verify The Fix
+
+1. Open `https://<production-domain>/api/health`.
+2. Expected result: HTTP 200 with `connectivity.status` set to `ok`.
+3. Open the app UI and confirm the storage indicator is green `KV`.
+4. If it shows an error state, open the indicator tooltip or `/api/health` to inspect whether the issue is DNS, auth, URL format, or timeout.
+5. Create a chat, refresh the page, and confirm the chat still appears.
+
+## Verify The Heartbeat
+
+The repo includes a Vercel Cron job in `vercel.json`:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/internal/redis-heartbeat",
+      "schedule": "17 5 * * *"
+    }
+  ]
+}
+```
+
+This runs once per day at 05:17 UTC on the Production deployment. The endpoint requires:
+
+```bash
+CRON_SECRET=<random secret>
+```
+
+Vercel automatically sends `Authorization: Bearer <CRON_SECRET>` when invoking cron jobs. The endpoint performs one Redis `SET` command on `__system:redis_heartbeat` with a 30-day TTL. That is enough real Redis activity for the demo while keeping command volume and cost negligible.
+
+To test manually after deployment:
+
+```bash
+curl -H "Authorization: Bearer $CRON_SECRET" \
+  https://<production-domain>/api/internal/redis-heartbeat
+```
+
+Expected response:
+
+```json
+{
+  "ok": true,
+  "key": "__system:redis_heartbeat",
+  "command": "SET"
+}
+```
+
+Then go to Vercel Project Settings > Cron Jobs and confirm `/api/internal/redis-heartbeat` is listed. Cron jobs run on Production deployments only.
+
+## If It Still Fails
+
+- `ENOTFOUND` or DNS errors usually mean the env vars still point at an archived/deleted host.
+- `401` or unauthorized errors usually mean the Redis token is stale or `CRON_SECRET` does not match the Authorization header.
+- URL format errors usually mean a native Redis URL was configured instead of the HTTPS REST URL.
+- A green Vercel integration card is not enough; verify with `/api/health` because the app needs live Redis connectivity, not just env var presence.
+
+## References
+
+- [Vercel Cron Jobs](https://vercel.com/docs/cron-jobs)
+- [Managing Vercel Cron Jobs](https://vercel.com/docs/cron-jobs/manage-cron-jobs)
+- [Upstash Vercel Integration](https://upstash.com/docs/redis/howto/vercelintegration)
+- [Upstash Redis FAQ](https://upstash.com/docs/redis/help/faq)

--- a/lib/assistant/generation.ts
+++ b/lib/assistant/generation.ts
@@ -1,0 +1,179 @@
+import { z } from "zod"
+import { makeAssistantArtifact, slugifyFilenamePart } from "@/lib/assistant/artifacts"
+import type { AssistantArtifact } from "@/lib/assistant/types"
+import { createParsedResponse } from "@/lib/openai"
+
+const MAX_CONTEXT_CHARS = 18000
+const MAX_THREAD_CHARS = 2600
+
+const AssistantDocumentSectionSchema = z.object({
+  heading: z.string().describe("Short section heading"),
+  bullets: z
+    .array(z.string())
+    .max(6)
+    .describe("Specific, non-repetitive bullets grounded in the provided chat context"),
+})
+
+const AssistantDocumentSourceSchema = z.object({
+  chatId: z.string().describe("Source chat ID exactly as provided"),
+  title: z.string().describe("Source chat title exactly as provided"),
+  reason: z.string().describe("Why this source was used"),
+  snippets: z.array(z.string()).max(3).describe("Short supporting snippets from this source"),
+})
+
+const AssistantDocumentSchema = z.object({
+  title: z.string().describe("Clear document title"),
+  overview: z
+    .string()
+    .describe("Brief synthesis of what the provided chats support. Do not invent facts."),
+  sections: z.array(AssistantDocumentSectionSchema).min(1).max(8),
+  sourcesUsed: z.array(AssistantDocumentSourceSchema).max(8),
+  missingOrAmbiguous: z
+    .array(z.string())
+    .max(8)
+    .describe("Facts, dates, numbers, or decisions that were not clear from the chats"),
+})
+
+export interface AssistantDocumentSourceInput {
+  chatId: string
+  title: string
+  updatedAt?: number
+  reason: string
+  snippet: string
+  transcript: string
+}
+
+export interface AssistantDocumentGenerationResult {
+  artifact: AssistantArtifact
+  summary: string
+  missingInfo: string[]
+}
+
+function truncateContext(text: string, maxChars: number): string {
+  const cleaned = text.replace(/\s+/g, " ").trim()
+  if (cleaned.length <= maxChars) return cleaned
+  return `${cleaned.slice(0, maxChars - 3).trim()}...`
+}
+
+function buildContextBlock(sources: AssistantDocumentSourceInput[]): string {
+  let usedChars = 0
+  const blocks: string[] = []
+
+  for (const source of sources) {
+    const transcript = truncateContext(source.transcript, MAX_THREAD_CHARS)
+    const block = [
+      `<chat id="${source.chatId}" title="${source.title}">`,
+      `Updated: ${source.updatedAt ? new Date(source.updatedAt).toISOString() : "unknown"}`,
+      `Why included: ${source.reason}`,
+      `Best snippet: ${source.snippet}`,
+      "Transcript excerpt:",
+      transcript,
+      "</chat>",
+    ].join("\n")
+
+    if (usedChars + block.length > MAX_CONTEXT_CHARS) break
+    blocks.push(block)
+    usedChars += block.length
+  }
+
+  return blocks.join("\n\n")
+}
+
+function renderMarkdownDocument(parsed: z.infer<typeof AssistantDocumentSchema>): string {
+  const lines: string[] = [
+    `# ${parsed.title}`,
+    "",
+    "## Overview",
+    parsed.overview,
+    "",
+  ]
+
+  for (const section of parsed.sections) {
+    lines.push(`## ${section.heading}`)
+    for (const bullet of section.bullets) {
+      lines.push(`- ${bullet}`)
+    }
+    lines.push("")
+  }
+
+  lines.push("## Sources Used")
+  for (const source of parsed.sourcesUsed) {
+    lines.push(`- ${source.title} (${source.chatId}): ${source.reason}`)
+    for (const snippet of source.snippets) {
+      lines.push(`  - ${snippet}`)
+    }
+  }
+  lines.push("")
+
+  lines.push("## Missing or Ambiguous Information")
+  if (parsed.missingOrAmbiguous.length === 0) {
+    lines.push("- No major missing information was identified from the provided context.")
+  } else {
+    for (const item of parsed.missingOrAmbiguous) {
+      lines.push(`- ${item}`)
+    }
+  }
+  lines.push("")
+  lines.push("_Generated from the provided demo chat context only._")
+  lines.push("")
+
+  return lines.join("\n")
+}
+
+export async function generateAssistantDocumentArtifact(args: {
+  request: string
+  interpretedGoal: string
+  title: string
+  sources: AssistantDocumentSourceInput[]
+}): Promise<AssistantDocumentGenerationResult | null> {
+  if (!process.env.OPENAI_API_KEY || args.sources.length === 0) {
+    return null
+  }
+
+  const context = buildContextBlock(args.sources)
+  if (!context) return null
+
+  const prompt = `Assistant request:
+${args.request}
+
+Interpreted goal:
+${args.interpretedGoal}
+
+Available chat context:
+${context}
+
+Create the downloadable document artifact. Use only the chat context above.
+Requirements:
+- Synthesize across chats instead of repeating the same source snippet.
+- Preserve exact facts, dates, numbers, units, and claims only when present.
+- Leave gaps explicit in missingOrAmbiguous.
+- Do not include generic advice unless it is clearly grounded in the provided chats.
+- Keep source chat IDs and titles exactly as provided.`
+
+  try {
+    const { parsed } = await createParsedResponse({
+      kind: "assistant",
+      input: prompt,
+      schema: AssistantDocumentSchema,
+      schemaName: "assistant_document_artifact",
+      instructions:
+        "You are the product-level Assistant inside a ChatGPT-like app. You create careful artifacts from provided chat context only. Never fabricate missing facts.",
+    })
+
+    if (!parsed) return null
+
+    const content = renderMarkdownDocument(parsed)
+    return {
+      artifact: makeAssistantArtifact({
+        kind: "markdown",
+        filename: `${slugifyFilenamePart(parsed.title || args.title)}.md`,
+        content,
+      }),
+      summary: `I synthesized a downloadable ${parsed.title.toLowerCase()} from ${args.sources.length} source chat${args.sources.length === 1 ? "" : "s"}.`,
+      missingInfo: parsed.missingOrAmbiguous,
+    }
+  } catch (error) {
+    console.error("[Assistant] Model document generation failed, using deterministic fallback:", error)
+    return null
+  }
+}

--- a/lib/assistant/retrieval.ts
+++ b/lib/assistant/retrieval.ts
@@ -1,4 +1,5 @@
 import { makeAssistantArtifact, rowsToCsv, slugifyFilenamePart } from "@/lib/assistant/artifacts"
+import { generateAssistantDocumentArtifact } from "@/lib/assistant/generation"
 import type {
   AssistantArtifact,
   AssistantChatThreadInput,
@@ -163,6 +164,26 @@ function truncate(text: string, max = MAX_SNIPPET): string {
   return `${cleaned.slice(0, max - 3).trim()}...`
 }
 
+function displayTitleForThread(thread: AssistantChatThreadInput): string {
+  const title = thread.title?.trim()
+  if (title && title.toLowerCase() !== "new chat") {
+    return title
+  }
+
+  const firstUserMessage = thread.messages.find(
+    (message) =>
+      message.role === "user" &&
+      message.text?.trim() &&
+      !message.isTaskCard &&
+      !isAssistantControlMessage(message.text)
+  )
+  if (firstUserMessage?.text) {
+    return truncate(firstUserMessage.text.replace(/^@\w+\s+/i, ""), 72)
+  }
+
+  return title || "Untitled chat"
+}
+
 function isAssistantControlMessage(text: string): boolean {
   return text.trim().toLowerCase().startsWith("@assistant ")
 }
@@ -179,7 +200,12 @@ function isAssistantOnlyThread(thread: AssistantChatThreadInput): boolean {
 
 function transcriptForThread(thread: AssistantChatThreadInput): string {
   const lines = thread.messages
-    .filter((message) => message.text?.trim() && !isAssistantControlMessage(message.text))
+    .filter(
+      (message) =>
+        message.text?.trim() &&
+        !message.isTaskCard &&
+        !isAssistantControlMessage(message.text)
+    )
     .map((message) => `${message.role}: ${message.text}`)
   return lines.join("\n").slice(0, MAX_THREAD_TEXT)
 }
@@ -328,7 +354,7 @@ function findSnippet(thread: AssistantChatThreadInput, tokens: string[]): string
 function sourcesFromScored(scored: ScoredThread[]): AssistantSource[] {
   return scored.map((item) => ({
     chatId: item.thread.id,
-    title: item.thread.title,
+    title: displayTitleForThread(item.thread),
     updatedAt: item.thread.updatedAt,
     reason: item.reason,
     snippet: item.snippet,
@@ -394,7 +420,7 @@ function extractLiftingRows(scored: ScoredThread[]): LiftingCsvRow[] {
             : "current strength"
 
         rows.push({
-          sourceChatTitle: item.thread.title,
+          sourceChatTitle: displayTitleForThread(item.thread),
           sourceChatId: item.thread.id,
           dateOrTimeframe: extractTimeframe(segment, item.thread),
           category,
@@ -505,19 +531,28 @@ function buildDocumentArtifact(request: string, scored: ScoredThread[]): {
   }
 
   const lower = request.toLowerCase()
-  const sequence =
-    lower.includes("calculus")
-      ? [
-          "Functions, graphs, and prerequisite review",
-          "Limits and continuity",
-          "Derivative rules and interpretation",
-          "Applications of derivatives",
-          "Basic integrals and the fundamental theorem",
-          "Integration techniques",
-          "Infinite series and Taylor polynomials",
-          "Mixed review and applied problems",
-        ]
-      : bullets.map((bullet) => bullet.replace(/^[-*]\s*/, ""))
+  const suggestedStructure = lower.includes("calculus")
+    ? [
+        "Functions, graphs, and prerequisite review",
+        "Limits and continuity",
+        "Derivative rules and interpretation",
+        "Applications of derivatives",
+        "Basic integrals and the fundamental theorem",
+        "Integration techniques",
+        "Infinite series and Taylor polynomials",
+        "Mixed review and applied problems",
+      ]
+    : [
+        "Key context gathered from matching chats",
+        "Decisions or recommendations explicitly supported by the chats",
+        "Source notes to review before using the artifact",
+        "Missing details to confirm",
+      ]
+
+  const sourceNotes = scored.slice(0, 6).map((item) => {
+    const title = displayTitleForThread(item.thread)
+    return `- ${title} (${item.thread.id}): ${item.snippet}`
+  })
 
   const content = [
     `# ${title}`,
@@ -525,14 +560,17 @@ function buildDocumentArtifact(request: string, scored: ScoredThread[]): {
     "## Interpreted Goal",
     interpretedGoalFor("cross_chat_artifact", request),
     "",
-    "## Context Extracted",
+    "## What I Found",
     ...bullets.map((bullet) => `- ${bullet}`),
     "",
-    "## Organized Plan",
-    ...sequence.map((item, index) => `${index + 1}. ${item}`),
+    "## Suggested Artifact Structure",
+    ...suggestedStructure.map((item, index) => `${index + 1}. ${item}`),
+    "",
+    "## Source Notes",
+    ...sourceNotes,
     "",
     "## Sources Used",
-    ...scored.map((item) => `- ${item.thread.title} (${item.thread.id}): ${item.snippet}`),
+    ...scored.map((item) => `- ${displayTitleForThread(item.thread)} (${item.thread.id}): ${item.reason}`),
     "",
     "## Missing or Ambiguous Information",
     "- Timing, exact workload, and mastery checks should be confirmed by the user.",
@@ -570,7 +608,7 @@ function buildCodexPrompt(thread: AssistantChatThreadInput, reason: string): str
 
   return [
     "@codex",
-    `Use the context from "${thread.title}" to finish the unresolved implementation work.`,
+    `Use the context from "${displayTitleForThread(thread)}" to finish the unresolved implementation work.`,
     "",
     "Context:",
     recent,
@@ -635,7 +673,7 @@ function detectOpenLoop(thread: AssistantChatThreadInput, codexOnly: boolean): A
 
   return {
     id: `${thread.id}-open-loop`,
-    chatTitle: thread.title,
+    chatTitle: displayTitleForThread(thread),
     chatId: thread.id,
     lastUpdated: thread.updatedAt,
     reason,
@@ -741,7 +779,7 @@ export function mergeAssistantThreads(
   return Array.from(map.values()).sort((a, b) => b.updatedAt - a.updatedAt)
 }
 
-export function createAssistantTaskResult(args: {
+export async function createAssistantTaskResult(args: {
   id: string
   request: string
   threads: AssistantChatThreadInput[]
@@ -752,7 +790,7 @@ export function createAssistantTaskResult(args: {
     resultSummary: string
     sources: AssistantSource[]
   } | null
-}): AssistantTaskResult {
+}): Promise<AssistantTaskResult> {
   const now = Date.now()
   const taskKind = classifyTaskKind(args.request)
   const interpretedGoal = interpretedGoalFor(taskKind, args.request)
@@ -784,10 +822,41 @@ export function createAssistantTaskResult(args: {
   const scored = selectRelevantThreads(args.request, args.threads)
   const sources = sourcesFromScored(scored)
   const lower = args.request.toLowerCase()
-  const artifactResult =
+  let artifactResult =
     lower.includes("lifting") || lower.includes("spreadsheet") || lower.includes("csv")
       ? buildLiftingArtifact(args.request, scored)
       : buildDocumentArtifact(args.request, scored)
+
+  if (
+    scored.length > 0 &&
+    !(lower.includes("lifting") || lower.includes("spreadsheet") || lower.includes("csv"))
+  ) {
+    const modelArtifact = await generateAssistantDocumentArtifact({
+      request: args.request,
+      interpretedGoal,
+      title: inferDocumentTitle(args.request),
+      sources: scored.slice(0, 8).map((item) => ({
+        chatId: item.thread.id,
+        title: displayTitleForThread(item.thread),
+        updatedAt: item.thread.updatedAt,
+        reason: item.reason,
+        snippet: item.snippet,
+        transcript: transcriptForThread(item.thread),
+      })),
+    })
+
+    if (modelArtifact) {
+      artifactResult = modelArtifact
+    } else if (artifactResult.artifact) {
+      artifactResult = {
+        ...artifactResult,
+        missingInfo: [
+          ...artifactResult.missingInfo,
+          "Model-assisted synthesis was unavailable, so this demo used a deterministic organizer.",
+        ],
+      }
+    }
+  }
 
   const proposedActions: AssistantProposedAction[] = []
   if (artifactResult.artifact) {

--- a/lib/openai/client.ts
+++ b/lib/openai/client.ts
@@ -8,7 +8,7 @@
  * - Consistent error handling
  *
  * Key principles:
- * - GPT-5 series requires reasoning.effort >= "low" (NOT "none")
+ * - Reasoning effort is centrally configurable and falls back when rejected
  * - Never send temperature, top_p, or max_output_tokens
  * - Use text.verbosity for response length control
  */
@@ -34,6 +34,7 @@ export type RequestKind =
   | "stacks" // Smart Stacks categorization (gpt-5-nano, reasoning: low)
   | "finder" // Chat finder reranking (gpt-5-mini, reasoning: low)
   | "codex" // Codex tasks (gpt-5.1-codex-mini, reasoning: low)
+  | "assistant" // Product-level Assistant tasks (gpt-5-mini, reasoning: low)
 
 /**
  * Request kinds that use previous_response_id chaining.
@@ -57,6 +58,7 @@ const DEFAULT_MODELS: Record<RequestKind, string> = {
   stacks: "gpt-5-nano",
   finder: "gpt-5-mini",
   codex: "gpt-5.1-codex-mini",
+  assistant: "gpt-5-mini",
 }
 
 /**
@@ -71,6 +73,7 @@ const MODEL_ENV_VARS: Record<RequestKind, string[]> = {
   stacks: ["OPENAI_MODEL_STACKS"],
   finder: ["OPENAI_MODEL_FINDER"],
   codex: ["OPENAI_MODEL_CODEX"],
+  assistant: ["OPENAI_MODEL_ASSISTANT", "OPENAI_ASSISTANT_MODEL"],
 }
 
 // Track if we've already warned about model mismatch (to avoid spamming logs)
@@ -125,17 +128,15 @@ export function getChainedChatModel(): string {
   return DEFAULT_MODELS.chat_deep
 }
 
-/**
- * Reasoning effort type - GPT-5 supports "minimal", "low", "medium", "high"
- * Note: "none" is NOT supported by GPT-5 series
- */
-type ReasoningEffort = "minimal" | "low" | "medium" | "high"
+type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+type TextVerbosity = "low" | "medium" | "high"
 
 /**
  * Reasoning effort for each request kind
  *
- * IMPORTANT: GPT-5 series models do NOT support "none"
- * For summarization, we use "minimal" for fastest performance
+ * Defaults can be overridden by kind-specific env vars. Some model families
+ * support slightly different reasoning values, so unsupported values are
+ * retried where a fallback is configured.
  */
 const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
   chat_fast: "low",
@@ -145,6 +146,7 @@ const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
   stacks: "low",
   finder: "low",
   codex: "low",
+  assistant: "low",
 }
 
 /**
@@ -152,12 +154,24 @@ const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
  */
 const REASONING_EFFORT_FALLBACK: Partial<Record<RequestKind, ReasoningEffort>> = {
   summarize: "low", // Fall back to "low" if "minimal" is rejected
+  assistant: "low",
+}
+
+const REASONING_ENV_VARS: Partial<Record<RequestKind, string[]>> = {
+  chat_fast: ["OPENAI_REASONING_FAST"],
+  chat_deep: ["OPENAI_REASONING_DEEP"],
+  summarize: ["OPENAI_REASONING_SUMMARIZE", "OPENAI_SUMMARY_REASONING"],
+  intent: ["OPENAI_REASONING_INTENT"],
+  stacks: ["OPENAI_REASONING_STACKS"],
+  finder: ["OPENAI_REASONING_FINDER"],
+  codex: ["OPENAI_REASONING_CODEX"],
+  assistant: ["OPENAI_REASONING_ASSISTANT", "OPENAI_ASSISTANT_REASONING"],
 }
 
 /**
  * Text verbosity for each request kind
  */
-const TEXT_VERBOSITY: Record<RequestKind, "low" | "medium" | "high"> = {
+const TEXT_VERBOSITY: Record<RequestKind, TextVerbosity> = {
   chat_fast: "low",
   chat_deep: "low",
   summarize: "low",
@@ -165,6 +179,46 @@ const TEXT_VERBOSITY: Record<RequestKind, "low" | "medium" | "high"> = {
   stacks: "low",
   finder: "low",
   codex: "medium", // Codex needs more verbose output for explanations
+  assistant: "high",
+}
+
+const TEXT_VERBOSITY_ENV_VARS: Partial<Record<RequestKind, string[]>> = {
+  assistant: ["OPENAI_TEXT_VERBOSITY_ASSISTANT", "OPENAI_ASSISTANT_VERBOSITY"],
+}
+
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+])
+
+const VALID_TEXT_VERBOSITY = new Set<TextVerbosity>(["low", "medium", "high"])
+const invalidConfigWarnings = new Set<string>()
+
+function warnInvalidConfigOnce(envVar: string, value: string, allowed: string): void {
+  const key = `${envVar}:${value}`
+  if (invalidConfigWarnings.has(key)) return
+  console.warn(`[OpenAI] Ignoring invalid ${envVar}="${value}". Allowed values: ${allowed}.`)
+  invalidConfigWarnings.add(key)
+}
+
+function readEnvOverride<T extends string>(
+  envVars: string[],
+  validValues: Set<T>,
+  allowedLabel: string
+): T | null {
+  for (const envVar of envVars) {
+    const value = process.env[envVar]?.trim()
+    if (!value) continue
+    if (validValues.has(value as T)) {
+      return value as T
+    }
+    warnInvalidConfigOnce(envVar, value, allowedLabel)
+  }
+  return null
 }
 
 // =============================================================================
@@ -221,7 +275,12 @@ export function getModel(kind: RequestKind): string {
  * Get the reasoning effort for a request kind
  */
 export function getReasoningEffort(kind: RequestKind): ReasoningEffort {
-  return REASONING_EFFORT[kind]
+  const override = readEnvOverride(
+    REASONING_ENV_VARS[kind] || [],
+    VALID_REASONING_EFFORTS,
+    "none, minimal, low, medium, high, xhigh"
+  )
+  return override ?? REASONING_EFFORT[kind]
 }
 
 /**
@@ -234,8 +293,13 @@ export function getReasoningEffortFallback(kind: RequestKind): ReasoningEffort |
 /**
  * Get the text verbosity for a request kind
  */
-export function getTextVerbosity(kind: RequestKind): "low" | "medium" | "high" {
-  return TEXT_VERBOSITY[kind]
+export function getTextVerbosity(kind: RequestKind): TextVerbosity {
+  const override = readEnvOverride(
+    TEXT_VERBOSITY_ENV_VARS[kind] || [],
+    VALID_TEXT_VERBOSITY,
+    "low, medium, high"
+  )
+  return override ?? TEXT_VERBOSITY[kind]
 }
 
 /**
@@ -269,7 +333,7 @@ type NonStreamingResponseParams = OpenAI.Responses.ResponseCreateParamsNonStream
  *
  * This function ensures:
  * - Correct model is selected
- * - Reasoning effort is set appropriately (GPT-5 supports "minimal", "low", "medium", "high")
+ * - Reasoning effort is set from central defaults or env overrides
  * - Text verbosity is set appropriately
  * - No unsupported parameters are sent
  * - Chained kinds (chat_fast, chat_deep) use store: true for previous_response_id
@@ -300,7 +364,7 @@ function buildCommonParams(
     input,
     store: shouldStore,
     stream: false,
-    reasoning: { effort: reasoning },
+    reasoning: { effort: reasoning } as NonStreamingResponseParams["reasoning"],
     text: {
       format: { type: "text" },
       verbosity,
@@ -443,15 +507,13 @@ export async function createSummarizeResponse(options: {
       throw error
     }
 
-    // Check if the API rejected "minimal" reasoning effort - retry with fallback
+    // Check if the API rejected the configured reasoning effort - retry with fallback
     if (
       config.reasoningFallback &&
       error instanceof OpenAI.APIError &&
-      (error.message.includes("reasoning") || 
-       error.message.includes("minimal") ||
-       error.code === "invalid_parameter_value")
+      isReasoningUnsupportedError(error)
     ) {
-      console.log(`[Summarize] "minimal" reasoning rejected, retrying with "${config.reasoningFallback}"`)
+      console.log(`[Summarize] "${reasoningUsed}" reasoning rejected, retrying with "${config.reasoningFallback}"`)
       reasoningUsed = config.reasoningFallback
 
       try {
@@ -497,6 +559,8 @@ export async function createParsedResponse<T extends z.ZodType>(options: {
   const client = getOpenAIClient()
   const model = getModel(options.kind)
   const reasoning = getReasoningEffort(options.kind)
+  const fallbackReasoning = getReasoningEffortFallback(options.kind)
+  const verbosity = getTextVerbosity(options.kind)
 
   const config = getConfigInfo(options.kind)
   console.log(`[OpenAI:${options.kind}] Parse request:`, {
@@ -505,16 +569,22 @@ export async function createParsedResponse<T extends z.ZodType>(options: {
     schema: options.schemaName,
   })
 
-  try {
-    const response = await client.responses.parse({
+  const attemptParse = async (reasoningToUse: ReasoningEffort) => {
+    return client.responses.parse({
       model,
       input: options.input,
       store: false,
-      reasoning: { effort: reasoning },
+      instructions: options.instructions,
+      reasoning: { effort: reasoningToUse } as NonStreamingResponseParams["reasoning"],
       text: {
         format: zodTextFormat(options.schema, options.schemaName),
+        verbosity,
       },
     })
+  }
+
+  try {
+    const response = await attemptParse(reasoning)
 
     console.log(`[OpenAI:${options.kind}] Parse response:`, {
       id: response.id,
@@ -528,9 +598,46 @@ export async function createParsedResponse<T extends z.ZodType>(options: {
       parsed: response.output_parsed as z.infer<T> | null,
     }
   } catch (error) {
+    if (
+      fallbackReasoning &&
+      fallbackReasoning !== reasoning &&
+      error instanceof OpenAI.APIError &&
+      isReasoningUnsupportedError(error)
+    ) {
+      console.log(
+        `[OpenAI:${options.kind}] "${reasoning}" reasoning rejected, retrying parse with "${fallbackReasoning}"`
+      )
+      try {
+        const response = await attemptParse(fallbackReasoning)
+        console.log(`[OpenAI:${options.kind}] Parse response:fallback`, {
+          id: response.id,
+          status: response.status,
+          model: response.model,
+          hasParsed: !!response.output_parsed,
+        })
+        return {
+          response,
+          parsed: response.output_parsed as z.infer<T> | null,
+        }
+      } catch (fallbackError) {
+        handleOpenAIError(fallbackError, options.kind, config)
+        throw fallbackError
+      }
+    }
     handleOpenAIError(error, options.kind, config)
     throw error
   }
+}
+
+function isReasoningUnsupportedError(error: { message: string; code?: string | null }): boolean {
+  const message = error.message.toLowerCase()
+  return (
+    message.includes("reasoning") ||
+    message.includes("effort") ||
+    message.includes("minimal") ||
+    error.code === "invalid_parameter_value" ||
+    error.code === "unsupported_value"
+  )
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- harden Assistant artifact generation with model-assisted structured Markdown synthesis, bounded source context, and deterministic fallback
- add Assistant-specific model, reasoning, and verbosity env knobs
- fix title/summary reliability by retrying unsupported reasoning values and returning deterministic fallbacks instead of leaving chats untitled
- make storage status verify live Redis connectivity, document database recovery, and clarify the daily Redis heartbeat cron

## Root Cause
- title generation was using the summary route with `minimal` reasoning; configured summary models can reject that value with `unsupported_value`, and the previous fallback did not catch that code
- Assistant document artifacts were assembled by repeating retrieved snippets instead of synthesizing across sources
- the storage indicator treated Redis env var presence as healthy even when the Upstash host was archived/unreachable

## Validation
- `npm_config_cache=/tmp/npm-cache npx tsc --noEmit`
- `npm_config_cache=/tmp/npm-cache npm run lint` (existing warnings only)
- `npm_config_cache=/tmp/npm-cache npm run build`
- Browser smoke test on `http://localhost:3003/demos/unified`: Assistant popup, sample workspace, CSV artifact task, inline `@assistant` open-loop card, and console error check
- `curl http://localhost:3003/api/storage`
- `curl http://localhost:3003/api/internal/redis-heartbeat` confirmed guarded failure when `CRON_SECRET` is missing locally
