### PR TITLE
[codex] Polish Assistant demo UX

### DIFF
--- a/app/api/assistant/run/route.ts
+++ b/app/api/assistant/run/route.ts
@@ -29,6 +29,23 @@ const AssistantThreadSchema = z.object({
   messages: z.array(AssistantMessageSchema).default([]),
 })
 
+const AssistantTaskKindSchema = z.enum([
+  "cross_chat_artifact",
+  "open_loops",
+  "current_chat_help",
+  "codex_prompt_draft",
+  "clarification",
+])
+
+const AssistantSourceSchema = z.object({
+  chatId: z.string(),
+  title: z.string(),
+  updatedAt: z.number().optional(),
+  reason: z.string(),
+  snippet: z.string(),
+  confidence: z.number().optional(),
+})
+
 const AssistantRunSchema = z.object({
   request: z.string().min(1),
   clientTaskId: z.string().optional(),
@@ -38,9 +55,9 @@ const AssistantRunSchema = z.object({
     .object({
       requestText: z.string(),
       interpretedGoal: z.string(),
-      taskKind: z.string(),
+      taskKind: AssistantTaskKindSchema,
       resultSummary: z.string(),
-      sources: z.array(z.unknown()),
+      sources: z.array(AssistantSourceSchema),
     })
     .nullable()
     .optional(),
@@ -120,7 +137,7 @@ export async function POST(request: NextRequest) {
       id: taskId,
       request: requestText,
       threads,
-      previousTask: null,
+      previousTask: parsed.data.previousTask ?? null,
     })
 
     return NextResponse.json({ task })
@@ -132,6 +149,6 @@ export async function POST(request: NextRequest) {
       request: requestText || "Assistant request",
       error: message,
     })
-    return NextResponse.json({ task }, { status: 200 })
+    return NextResponse.json({ task, error: message }, { status: 500 })
   }
 }

--- a/app/demos/unified/page.tsx
+++ b/app/demos/unified/page.tsx
@@ -140,6 +140,61 @@ function buildTaskContextInput(task: CodexTask): string | null {
   return lines.join("\n")
 }
 
+function buildAssistantContextInput(task: AssistantTaskResult): string | null {
+  if (task.status !== "ready" && task.status !== "no_results") return null
+
+  const lines: string[] = [
+    "Assistant output added to this chat's hidden context.",
+    "",
+    `Original Assistant request: ${task.requestText}`,
+    `Interpreted goal: ${task.interpretedGoal}`,
+    "",
+    "## Result",
+    task.resultSummary,
+    "",
+  ]
+
+  if (task.artifact) {
+    const maxArtifactChars = 14000
+    const content =
+      task.artifact.content.length > maxArtifactChars
+        ? `${task.artifact.content.slice(0, maxArtifactChars).trim()}\n\n[Artifact truncated for chat context.]`
+        : task.artifact.content
+    lines.push(`## Artifact: ${task.artifact.filename}`)
+    lines.push(content)
+    lines.push("")
+  }
+
+  if (task.openLoops?.length) {
+    lines.push("## Open Loops")
+    for (const item of task.openLoops) {
+      lines.push(`- ${item.chatTitle}: ${item.reason} Next action: ${item.nextAction}`)
+    }
+    lines.push("")
+  }
+
+  if (task.sources.length > 0) {
+    lines.push("## Sources Used")
+    for (const source of task.sources.slice(0, 8)) {
+      lines.push(`- ${source.title} (${source.chatId}): ${source.reason}`)
+      if (source.snippet) {
+        lines.push(`  Snippet: ${source.snippet}`)
+      }
+    }
+    lines.push("")
+  }
+
+  if (task.missingInfo?.length) {
+    lines.push("## Missing or Ambiguous Information")
+    for (const item of task.missingInfo) {
+      lines.push(`- ${item}`)
+    }
+    lines.push("")
+  }
+
+  return lines.join("\n").trim()
+}
+
 // =============================================================================
 // Extended Chat Message Type (with task support)
 // =============================================================================
@@ -288,8 +343,7 @@ function createPendingAssistantTask(id: string, requestText: string): AssistantT
     updatedAt: now,
     status: "searching",
     requestText,
-    interpretedGoal:
-      "Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.",
+    interpretedGoal: "Review workspace context and prepare a product-level Assistant result.",
     taskKind: "clarification",
     progress: ["queued", "interpreting", "searching"],
     sources: [],
@@ -367,6 +421,9 @@ function UnifiedDemoContent() {
   // ASSISTANT STATE
   // ==========================================================================
   const [assistantTasks, setAssistantTasks] = useState<Record<string, AssistantTaskResult>>({})
+  const [includedAssistantContextIds, setIncludedAssistantContextIds] = useState<Set<string>>(
+    () => new Set()
+  )
 
   // ==========================================================================
   // FIND STATE
@@ -2141,6 +2198,60 @@ function UnifiedDemoContent() {
     toast.success("Prompt inserted")
   }
 
+  const handleIncludeAssistantContext = async (task: AssistantTaskResult) => {
+    if (includedAssistantContextIds.has(task.id)) return
+
+    const contextInput = buildAssistantContextInput(task)
+    if (!contextInput) {
+      toast.error("Assistant output is not ready to include yet")
+      return
+    }
+
+    try {
+      logAuditClient("assistant", "assistant_context_ingest_start", {
+        taskId: task.id,
+        threadId: storedThreadIdRef.current,
+        previousResponseId: lastResponseIdRef.current,
+      })
+
+      const responseData = await enqueueChain(async () =>
+        respondWithRetry({
+          input: contextInput,
+          mode: "deep",
+          source: "ingestion",
+        })
+      )
+
+      lastResponseIdRef.current = responseData.id
+      setState((prev) => ({
+        ...prev,
+        lastResponseId: responseData.id,
+      }))
+
+      if (storedThreadIdRef.current) {
+        await updateStoredThread(storedThreadIdRef.current, {
+          lastResponseId: responseData.id,
+        })
+      }
+
+      setIncludedAssistantContextIds((prev) => {
+        const next = new Set(prev)
+        next.add(task.id)
+        return next
+      })
+
+      logAuditClient("assistant", "assistant_context_ingest_complete", {
+        taskId: task.id,
+        threadId: storedThreadIdRef.current,
+        newResponseId: responseData.id,
+      })
+      toast.success("Assistant output added to chat context")
+    } catch (error) {
+      console.error("Failed to include Assistant context:", error)
+      toast.error("Could not add Assistant output to chat context")
+    }
+  }
+
   const handleCloseAssistantTask = (taskId: string) => {
     setState((prev) => ({
       ...prev,
@@ -2152,6 +2263,12 @@ function UnifiedDemoContent() {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [taskId]: _removed, ...rest } = prev
       return rest
+    })
+    setIncludedAssistantContextIds((prev) => {
+      if (!prev.has(taskId)) return prev
+      const next = new Set(prev)
+      next.delete(taskId)
+      return next
     })
   }
 
@@ -2319,6 +2436,8 @@ function UnifiedDemoContent() {
                         onClose={() => handleCloseAssistantTask(task.id)}
                         onOpenChat={handleOpenAssistantChat}
                         onInsertPrompt={handleInsertAssistantPrompt}
+                        onIncludeInChatContext={handleIncludeAssistantContext}
+                        isIncludedInChatContext={includedAssistantContextIds.has(task.id)}
                       />
                     )
                   }

--- a/components/assistant/assistant-popup.tsx
+++ b/components/assistant/assistant-popup.tsx
@@ -8,11 +8,18 @@ import { AssistantTaskCard } from "@/components/assistant/assistant-task-card"
 import type { AssistantTaskResult } from "@/lib/assistant/types"
 
 const SUGGESTIONS = [
-  "Find unfinished chats from this week",
-  "Extract lifting numbers into a spreadsheet",
-  "Turn calculus chats into a curriculum",
-  "Find chats that need a Codex follow-up",
-  "Summarize where I left off",
+  {
+    label: "Build a plan",
+    prompt: "Synthesize relevant chats into a clear plan I can follow",
+  },
+  {
+    label: "Recover loose ends",
+    prompt: "Find unfinished chats from this week and brief me on next actions",
+  },
+  {
+    label: "Create a spreadsheet",
+    prompt: "Extract lifting numbers into a spreadsheet",
+  },
 ]
 
 function createPendingTask(id: string, request: string): AssistantTaskResult {
@@ -23,8 +30,7 @@ function createPendingTask(id: string, request: string): AssistantTaskResult {
     updatedAt: now,
     status: "searching",
     requestText: request,
-    interpretedGoal:
-      "Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.",
+    interpretedGoal: "Review workspace context and prepare a product-level Assistant result.",
     taskKind: "clarification",
     progress: ["queued", "interpreting", "searching"],
     sources: [],
@@ -89,7 +95,7 @@ export function AssistantPopup({
   }
 
   return (
-    <div className="absolute right-0 top-full z-40 mt-2 w-[440px] overflow-hidden rounded-xl border border-border bg-card shadow-xl dark:shadow-black/30">
+    <div className="absolute right-0 top-full z-40 mt-2 w-[420px] overflow-hidden rounded-xl border border-border bg-card shadow-xl dark:shadow-black/30">
       <div className="border-b border-border bg-teal-500/5 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-3">
@@ -99,7 +105,7 @@ export function AssistantPopup({
             <div>
               <h2 className="text-sm font-semibold">Assistant</h2>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Ask the Assistant to work across your chats, recover unfinished threads, or turn scattered context into files.
+                Work across chats, recover loose ends, and turn context into files.
               </p>
             </div>
           </div>
@@ -110,14 +116,14 @@ export function AssistantPopup({
       </div>
 
       <div className="space-y-3 p-3">
-        <form onSubmit={handleSubmit} className="flex items-end gap-2">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
           <textarea
             value={input}
             onChange={(event) => setInput(event.target.value)}
-            placeholder="Ask Assistant..."
-            rows={2}
+            placeholder="Ask across your chats..."
+            rows={1}
             disabled={isRunning}
-            className="min-h-[56px] flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-60"
+            className="min-h-10 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-60"
           />
           <Button type="submit" size="icon" className="h-10 w-10 shrink-0" disabled={!input.trim() || isRunning}>
             {isRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
@@ -127,31 +133,34 @@ export function AssistantPopup({
         <div className="flex flex-wrap gap-2">
           {SUGGESTIONS.map((suggestion) => (
             <Button
-              key={suggestion}
+              key={suggestion.label}
               type="button"
               variant="outline"
               size="sm"
               className="h-7 rounded-full px-2.5 text-[11px]"
               disabled={isRunning}
-              onClick={() => runTask(suggestion)}
+              onClick={() => runTask(suggestion.prompt)}
             >
-              {suggestion}
+              {suggestion.label}
             </Button>
           ))}
         </div>
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-8 gap-1.5 text-xs"
-          onClick={onLoadSampleWorkspace}
-        >
-          <Database className="h-3.5 w-3.5" />
-          Load sample Assistant workspace
-        </Button>
+        <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/30 px-3 py-2">
+          <p className="text-xs text-muted-foreground">Need demo data?</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs"
+            onClick={onLoadSampleWorkspace}
+          >
+            <Database className="h-3.5 w-3.5" />
+            Load samples
+          </Button>
+        </div>
 
-        <div className="max-h-[560px] overflow-auto">
+        <div className="max-h-[500px] overflow-auto">
           {task ? (
             <AssistantTaskCard
               task={task}

--- a/components/assistant/assistant-task-card.tsx
+++ b/components/assistant/assistant-task-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FormEvent, useState } from "react"
+import { FormEvent, useEffect, useState } from "react"
 import {
   AlertCircle,
   ChevronDown,
@@ -22,6 +22,7 @@ import {
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { MarkdownContent } from "@/components/ui/markdown-content"
+import { docxFilenameFor, makeDocxBlobFromMarkdown } from "@/lib/assistant/docx"
 import { cn } from "@/lib/utils"
 import type {
   AssistantArtifact,
@@ -75,12 +76,31 @@ const TASK_KIND_LABELS: Record<AssistantTaskResult["taskKind"], string> = {
   clarification: "Assistant",
 }
 
+const WORKING_STEPS = [
+  "Interpreting the request",
+  "Reviewing relevant chats",
+  "Checking evidence",
+  "Preparing the result",
+]
+
 function downloadArtifact(artifact: AssistantArtifact) {
   const blob = new Blob([artifact.content], { type: artifact.mimeType })
   const url = URL.createObjectURL(blob)
   const link = document.createElement("a")
   link.href = url
   link.download = artifact.filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+function downloadDocxArtifact(artifact: AssistantArtifact) {
+  const blob = makeDocxBlobFromMarkdown(artifact.content, artifact.filename)
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = docxFilenameFor(artifact.filename)
   document.body.appendChild(link)
   link.click()
   link.remove()
@@ -102,37 +122,59 @@ function copyText(text: string, label = "Copied") {
   toast.success(label)
 }
 
-function ProgressList({ task }: { task: AssistantTaskResult }) {
-  const steps: Array<{ status: AssistantTaskStatus; label: string }> = [
-    { status: "interpreting", label: "Interpreted request" },
-    { status: "searching", label: "Reviewed available chats" },
-    { status: "reviewing", label: "Checked evidence" },
-    { status: "generating", label: "Prepared result" },
-  ]
+function useWorkingStep(isWorking: boolean, createdAt: number): number {
+  const [now, setNow] = useState(() => Date.now())
 
-  const done = new Set(task.progress)
-  const isRunning = !TERMINAL_STATUSES.has(task.status)
+  useEffect(() => {
+    if (!isWorking) return
+    const interval = window.setInterval(() => setNow(Date.now()), 900)
+    return () => window.clearInterval(interval)
+  }, [isWorking])
 
+  const elapsedMs = Math.max(0, now - createdAt)
+  return Math.min(WORKING_STEPS.length - 1, Math.floor(elapsedMs / 1600))
+}
+
+function WorkingState({
+  stepIndex,
+  compact = false,
+}: {
+  stepIndex: number
+  compact?: boolean
+}) {
   return (
-    <div className="flex flex-wrap gap-2">
-      {steps.map((step) => {
-        const complete = done.has(step.status) || task.status === "ready" || task.status === "no_results"
-        return (
-          <div
-            key={step.status}
-            className="flex h-8 min-w-[150px] flex-1 items-center gap-2 rounded-md border border-border/60 bg-background/60 px-2.5 text-xs"
-          >
-            {complete ? (
-              <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-            ) : isRunning ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-            ) : (
-              <span className="h-3.5 w-3.5 rounded-full border border-border" />
-            )}
-            <span className="truncate">{step.label}</span>
-          </div>
-        )
-      })}
+    <div className="rounded-lg border border-teal-500/15 bg-teal-500/5 px-3 py-3">
+      <div className="flex items-center gap-2 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin text-teal-700 dark:text-teal-300" />
+        <span className="font-medium">{WORKING_STEPS[stepIndex]}</span>
+      </div>
+      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-background">
+        <div
+          className="h-full rounded-full bg-teal-600 transition-all duration-500 dark:bg-teal-300"
+          style={{ width: `${((stepIndex + 1) / WORKING_STEPS.length) * 100}%` }}
+        />
+      </div>
+      {!compact && (
+        <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+          {WORKING_STEPS.map((step, index) => (
+            <div key={step} className="flex min-w-0 items-center gap-1.5">
+              {index < stepIndex ? (
+                <Check className="h-3 w-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <span
+                  className={cn(
+                    "h-2 w-2 shrink-0 rounded-full",
+                    index === stepIndex ? "bg-teal-600 dark:bg-teal-300" : "bg-muted-foreground/25"
+                  )}
+                />
+              )}
+              <span className={cn("truncate", index === stepIndex && "text-foreground")}>
+                {step}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -140,9 +182,11 @@ function ProgressList({ task }: { task: AssistantTaskResult }) {
 function SourceList({
   sources,
   onOpenChat,
+  dense = false,
 }: {
   sources: AssistantSource[]
   onOpenChat?: (chatId: string) => void
+  dense?: boolean
 }) {
   if (sources.length === 0) {
     return (
@@ -157,7 +201,10 @@ function SourceList({
       {sources.slice(0, 5).map((source) => (
         <div
           key={`${source.chatId}-${source.title}`}
-          className="rounded-lg border border-border/70 bg-background/60 px-3 py-2.5"
+          className={cn(
+            "rounded-lg border border-border/70 bg-background/60",
+            dense ? "px-2.5 py-2" : "px-3 py-2.5"
+          )}
         >
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
@@ -179,7 +226,7 @@ function SourceList({
               </Button>
             )}
           </div>
-          {source.snippet && (
+          {source.snippet && !dense && (
             <p className="mt-2 rounded-md bg-muted/50 px-2 py-1.5 text-xs leading-relaxed text-muted-foreground">
               {source.snippet}
             </p>
@@ -191,6 +238,8 @@ function SourceList({
 }
 
 function ArtifactPanel({ artifact }: { artifact: AssistantArtifact }) {
+  const supportsDocx = artifact.kind === "markdown"
+
   return (
     <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-3">
       <div className="flex items-center justify-between gap-3">
@@ -205,15 +254,29 @@ function ArtifactPanel({ artifact }: { artifact: AssistantArtifact }) {
             </p>
           </div>
         </div>
-        <Button
-          type="button"
-          size="sm"
-          className="h-8 shrink-0 gap-1.5"
-          onClick={() => downloadArtifact(artifact)}
-        >
-          <Download className="h-3.5 w-3.5" />
-          Download
-        </Button>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant={supportsDocx ? "outline" : "default"}
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => downloadArtifact(artifact)}
+          >
+            <Download className="h-3.5 w-3.5" />
+            {supportsDocx ? "Markdown" : "Download"}
+          </Button>
+          {supportsDocx && (
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => downloadDocxArtifact(artifact)}
+            >
+              <FileText className="h-3.5 w-3.5" />
+              DOCX
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   )
@@ -250,6 +313,75 @@ function ArtifactPreview({
         )}
       </div>
     </div>
+  )
+}
+
+function SourcesDetails({
+  task,
+  onOpenChat,
+}: {
+  task: AssistantTaskResult
+  onOpenChat?: (chatId: string) => void
+}) {
+  const hasSources = task.sources.length > 0
+  const label = hasSources
+    ? `${task.sources.length} source${task.sources.length === 1 ? "" : "s"} used`
+    : "No matching sources"
+
+  if (!hasSources) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+        <Search className="h-3.5 w-3.5" />
+        <span>{label}</span>
+        <span>•</span>
+        <span>{task.reviewedChatCount} reviewed</span>
+      </div>
+    )
+  }
+
+  return (
+    <details className="group rounded-lg border border-border/70 bg-muted/20">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <p className="text-[10px] font-medium uppercase text-muted-foreground">
+            Sources Used
+          </p>
+          <span className="truncate text-xs text-muted-foreground">
+            {label} • {task.reviewedChatCount} reviewed
+          </span>
+        </div>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+      </summary>
+      <div className="border-t border-border/70 p-2">
+        <SourceList sources={task.sources} onOpenChat={onOpenChat} dense />
+      </div>
+    </details>
+  )
+}
+
+function MissingInfoDetails({ items }: { items?: string[] }) {
+  if (!items?.length) return null
+
+  return (
+    <details className="group rounded-lg border border-border/70 bg-muted/20">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-[10px] font-medium uppercase text-muted-foreground">
+            Missing or Ambiguous
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {items.length} item{items.length === 1 ? "" : "s"} to confirm
+          </p>
+        </div>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+      </summary>
+      <ul className="space-y-1 border-t border-border/70 px-3 py-2 text-xs text-muted-foreground">
+        {items.map((item) => (
+          <li key={item}>- {item}</li>
+        ))}
+      </ul>
+    </details>
   )
 }
 
@@ -338,18 +470,17 @@ function OpenLoopItem({
 
 function ProposedActions({
   actions,
-  artifact,
-  onOpenChat,
   onInsertPrompt,
 }: {
   actions: AssistantProposedAction[]
-  artifact?: AssistantArtifact
-  onOpenChat?: (chatId: string) => void
   onInsertPrompt?: (prompt: string) => void
 }) {
   const actionable = actions.filter(
     (action, index, all) =>
-      index === all.findIndex((candidate) => candidate.type === action.type && candidate.chatId === action.chatId)
+      action.type === "insert_codex_prompt" &&
+      action.prompt &&
+      onInsertPrompt &&
+      index === all.findIndex((candidate) => candidate.type === action.type && candidate.prompt === action.prompt)
   )
 
   if (actionable.length === 0) return null
@@ -357,36 +488,6 @@ function ProposedActions({
   return (
     <div className="flex flex-wrap gap-2">
       {actionable.slice(0, 5).map((action) => {
-        if (action.type === "download_artifact" && artifact) {
-          return (
-            <Button
-              key={action.id}
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8 gap-1.5"
-              onClick={() => downloadArtifact(artifact)}
-            >
-              <Download className="h-3.5 w-3.5" />
-              {action.label}
-            </Button>
-          )
-        }
-        if (action.type === "open_chat" && action.chatId && onOpenChat) {
-          return (
-            <Button
-              key={action.id}
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8 gap-1.5"
-              onClick={() => onOpenChat(action.chatId!)}
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {action.label}
-            </Button>
-          )
-        }
         if (action.type === "insert_codex_prompt" && action.prompt && onInsertPrompt) {
           return (
             <Button
@@ -427,6 +528,7 @@ export function AssistantTaskCard({
     open: Boolean(task.artifact) && !compact,
   }))
   const isWorking = !TERMINAL_STATUSES.has(task.status)
+  const workingStep = useWorkingStep(isWorking, task.createdAt)
   const artifactFilename = task.artifact?.filename
   const showArtifactPreview =
     artifactPreviewState.filename === artifactFilename
@@ -491,15 +593,15 @@ export function AssistantTaskCard({
   }
 
   const followUpForm = onFollowUp ? (
-    <form onSubmit={handleFollowUp} className="flex items-end gap-2 border-t border-border/70 pt-3">
+    <form onSubmit={handleFollowUp} className="flex items-center gap-2 rounded-lg border border-border/70 bg-background/60 p-2">
       <textarea
         value={followUp}
         onChange={(event) => setFollowUp(event.target.value)}
         placeholder="Follow up with Assistant..."
         rows={1}
-        className="min-h-9 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="min-h-8 flex-1 resize-none bg-transparent px-1 py-1 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
       />
-      <Button type="submit" size="sm" disabled={!followUp.trim()}>
+      <Button type="submit" size="sm" className="h-8" disabled={!followUp.trim()}>
         Send
       </Button>
     </form>
@@ -548,10 +650,7 @@ export function AssistantTaskCard({
           </div>
 
           {isWorking ? (
-            <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Reviewing chats and preparing the result...
-            </div>
+            <WorkingState stepIndex={workingStep} compact />
           ) : (
             <>
               {task.status === "failed" && (
@@ -594,7 +693,7 @@ export function AssistantTaskCard({
                       <ChevronUp className="hidden h-3 w-3 group-open:block" />
                     </summary>
                     <div className="mt-2 min-w-[320px]">
-                      <SourceList sources={task.sources} onOpenChat={onOpenChat} />
+                      <SourceList sources={task.sources} onOpenChat={onOpenChat} dense />
                     </div>
                   </details>
                 )}
@@ -656,13 +755,7 @@ export function AssistantTaskCard({
 
       <div className="space-y-4 p-4">
         {isWorking && (
-          <>
-            <ProgressList task={task} />
-            <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Reviewing available chat context...
-            </div>
-          </>
+          <WorkingState stepIndex={workingStep} />
         )}
 
         {!isWorking && (
@@ -714,36 +807,12 @@ export function AssistantTaskCard({
               </div>
             )}
 
-            <div>
-              <div className="mb-2 flex items-center gap-2">
-                <Search className="h-3.5 w-3.5 text-muted-foreground" />
-                <p className="text-[10px] font-medium uppercase text-muted-foreground">
-                  Sources Used
-                </p>
-                <span className="text-[10px] text-muted-foreground">
-                  {task.reviewedChatCount} reviewed
-                </span>
-              </div>
-              <SourceList sources={task.sources} onOpenChat={onOpenChat} />
-            </div>
+            <SourcesDetails task={task} onOpenChat={onOpenChat} />
 
-            {task.missingInfo && task.missingInfo.length > 0 && (
-              <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
-                <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
-                  Missing or Ambiguous
-                </p>
-                <ul className="space-y-1 text-xs text-muted-foreground">
-                  {task.missingInfo.map((item) => (
-                    <li key={item}>- {item}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            <MissingInfoDetails items={task.missingInfo} />
 
             <ProposedActions
               actions={task.proposedActions}
-              artifact={task.artifact}
-              onOpenChat={onOpenChat}
               onInsertPrompt={onInsertPrompt}
             />
 

--- a/components/assistant/assistant-task-card.tsx
+++ b/components/assistant/assistant-task-card.tsx
@@ -3,14 +3,18 @@
 import { FormEvent, useState } from "react"
 import {
   AlertCircle,
+  ChevronDown,
+  ChevronUp,
   Check,
   Clipboard,
   Compass,
   Download,
   ExternalLink,
+  Eye,
   FileText,
   Loader2,
   MessageSquare,
+  Plus,
   Search,
   Sparkles,
   X,
@@ -57,6 +61,18 @@ interface AssistantTaskCardProps {
   onClose?: () => void
   onOpenChat?: (chatId: string) => void
   onInsertPrompt?: (prompt: string) => void
+  onIncludeInChatContext?: (task: AssistantTaskResult) => void
+  isIncludedInChatContext?: boolean
+}
+
+const TERMINAL_STATUSES = new Set<AssistantTaskStatus>(["ready", "failed", "no_results"])
+
+const TASK_KIND_LABELS: Record<AssistantTaskResult["taskKind"], string> = {
+  cross_chat_artifact: "Artifact",
+  open_loops: "Open loops",
+  current_chat_help: "Current chat",
+  codex_prompt_draft: "Codex follow-up",
+  clarification: "Assistant",
 }
 
 function downloadArtifact(artifact: AssistantArtifact) {
@@ -95,16 +111,16 @@ function ProgressList({ task }: { task: AssistantTaskResult }) {
   ]
 
   const done = new Set(task.progress)
-  const isRunning = !["ready", "failed", "no_results"].includes(task.status)
+  const isRunning = !TERMINAL_STATUSES.has(task.status)
 
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="flex flex-wrap gap-2">
       {steps.map((step) => {
         const complete = done.has(step.status) || task.status === "ready" || task.status === "no_results"
         return (
           <div
             key={step.status}
-            className="flex items-center gap-2 rounded-md border border-border/60 bg-background/60 px-2.5 py-2 text-xs"
+            className="flex h-8 min-w-[150px] flex-1 items-center gap-2 rounded-md border border-border/60 bg-background/60 px-2.5 text-xs"
           >
             {complete ? (
               <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
@@ -198,6 +214,40 @@ function ArtifactPanel({ artifact }: { artifact: AssistantArtifact }) {
           <Download className="h-3.5 w-3.5" />
           Download
         </Button>
+      </div>
+    </div>
+  )
+}
+
+function ArtifactPreview({
+  artifact,
+  compact = false,
+}: {
+  artifact: AssistantArtifact
+  compact?: boolean
+}) {
+  const maxChars = compact ? 5000 : 12000
+  const content =
+    artifact.content.length > maxChars
+      ? `${artifact.content.slice(0, maxChars).trim()}\n\n...`
+      : artifact.content
+  const isMarkdown = artifact.kind === "markdown"
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70 bg-background">
+      <div
+        className={cn(
+          "overflow-auto px-3 py-3 text-sm",
+          compact ? "max-h-56" : "max-h-80"
+        )}
+      >
+        {isMarkdown ? (
+          <MarkdownContent content={content} />
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-muted-foreground">
+            {content}
+          </pre>
+        )}
       </div>
     </div>
   )
@@ -365,9 +415,23 @@ export function AssistantTaskCard({
   onClose,
   onOpenChat,
   onInsertPrompt,
+  onIncludeInChatContext,
+  isIncludedInChatContext = false,
 }: AssistantTaskCardProps) {
   const [followUp, setFollowUp] = useState("")
-  const isWorking = !["ready", "failed", "no_results"].includes(task.status)
+  const [artifactPreviewState, setArtifactPreviewState] = useState<{
+    filename?: string
+    open: boolean
+  }>(() => ({
+    filename: task.artifact?.filename,
+    open: Boolean(task.artifact) && !compact,
+  }))
+  const isWorking = !TERMINAL_STATUSES.has(task.status)
+  const artifactFilename = task.artifact?.filename
+  const showArtifactPreview =
+    artifactPreviewState.filename === artifactFilename
+      ? artifactPreviewState.open
+      : Boolean(artifactFilename) && !compact
 
   const handleFollowUp = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -377,11 +441,177 @@ export function AssistantTaskCard({
     onFollowUp(text, task.id)
   }
 
+  const canIncludeInContext =
+    Boolean(onIncludeInChatContext) && task.status === "ready" && Boolean(task.artifact || task.resultSummary)
+  const sourcesSummary = `${task.reviewedChatCount} chat${task.reviewedChatCount === 1 ? "" : "s"} reviewed${
+    task.sources.length ? ` • ${task.sources.length} source${task.sources.length === 1 ? "" : "s"} used` : ""
+  }`
+
+  const renderArtifactActions = () => {
+    if (!task.artifact && !canIncludeInContext) return null
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        {task.artifact && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() =>
+              setArtifactPreviewState({
+                filename: artifactFilename,
+                open: !showArtifactPreview,
+              })
+            }
+          >
+            {showArtifactPreview ? (
+              <ChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <Eye className="h-3.5 w-3.5" />
+            )}
+            {showArtifactPreview ? "Hide preview" : "Preview output"}
+          </Button>
+        )}
+        {canIncludeInContext && onIncludeInChatContext && (
+          <Button
+            type="button"
+            variant={isIncludedInChatContext ? "secondary" : "outline"}
+            size="sm"
+            className="h-8 gap-1.5"
+            disabled={isIncludedInChatContext}
+            onClick={() => onIncludeInChatContext(task)}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {isIncludedInChatContext ? "Included in chat context" : "Include in chat context"}
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  const followUpForm = onFollowUp ? (
+    <form onSubmit={handleFollowUp} className="flex items-end gap-2 border-t border-border/70 pt-3">
+      <textarea
+        value={followUp}
+        onChange={(event) => setFollowUp(event.target.value)}
+        placeholder="Follow up with Assistant..."
+        rows={1}
+        className="min-h-9 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      />
+      <Button type="submit" size="sm" disabled={!followUp.trim()}>
+        Send
+      </Button>
+    </form>
+  ) : null
+
+  if (compact) {
+    return (
+      <div className="overflow-hidden rounded-lg border border-teal-500/20 bg-card shadow-sm">
+        <div className="space-y-3 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-start gap-2.5">
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-teal-500/10">
+                <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <p className="font-medium">Assistant</p>
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    {TASK_KIND_LABELS[task.taskKind]}
+                  </span>
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                      STATUS_STYLES[task.status]
+                    )}
+                  >
+                    {STATUS_LABELS[task.status]}
+                  </span>
+                </div>
+                <p className="mt-1 break-words text-sm leading-relaxed text-muted-foreground">
+                  {task.requestText}
+                </p>
+              </div>
+            </div>
+            {onClose && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                onClick={onClose}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+
+          {isWorking ? (
+            <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Reviewing chats and preparing the result...
+            </div>
+          ) : (
+            <>
+              {task.status === "failed" && (
+                <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{task.error || task.resultSummary}</span>
+                </div>
+              )}
+
+              <div className="rounded-lg bg-muted/30 px-3 py-2 text-sm leading-relaxed">
+                <MarkdownContent content={task.resultSummary} />
+              </div>
+
+              {task.artifact && <ArtifactPanel artifact={task.artifact} />}
+              {renderArtifactActions()}
+              {task.artifact && showArtifactPreview && (
+                <ArtifactPreview artifact={task.artifact} compact />
+              )}
+
+              {task.openLoops && task.openLoops.length > 0 && (
+                <div className="space-y-2">
+                  {task.openLoops.slice(0, 3).map((item) => (
+                    <OpenLoopItem
+                      key={item.id}
+                      item={item}
+                      onOpenChat={onOpenChat}
+                      onInsertPrompt={onInsertPrompt}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div className="flex items-center justify-between gap-2 rounded-md bg-background/70 px-3 py-2 text-xs text-muted-foreground">
+                <span>{sourcesSummary}</span>
+                {task.sources.length > 0 && (
+                  <details className="group">
+                    <summary className="flex cursor-pointer list-none items-center gap-1 font-medium text-foreground">
+                      Sources
+                      <ChevronDown className="h-3 w-3 group-open:hidden" />
+                      <ChevronUp className="hidden h-3 w-3 group-open:block" />
+                    </summary>
+                    <div className="mt-2 min-w-[320px]">
+                      <SourceList sources={task.sources} onOpenChat={onOpenChat} />
+                    </div>
+                  </details>
+                )}
+              </div>
+
+              {followUpForm}
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-xl border border-teal-500/20 bg-card shadow-sm dark:shadow-md dark:shadow-black/20",
-        compact ? "max-h-[560px]" : "w-full"
+        "mx-auto w-full max-w-5xl overflow-hidden rounded-xl border border-teal-500/20 bg-card shadow-sm dark:shadow-md dark:shadow-black/20"
       )}
     >
       <div className="border-b border-border/70 bg-teal-500/5 px-4 py-3">
@@ -393,6 +623,9 @@ export function AssistantTaskCard({
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <p className="font-medium">Assistant</p>
+                <span className="rounded-full bg-background/70 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  {TASK_KIND_LABELS[task.taskKind]}
+                </span>
                 <span
                   className={cn(
                     "rounded-full px-2 py-0.5 text-[10px] font-medium",
@@ -421,113 +654,109 @@ export function AssistantTaskCard({
         </div>
       </div>
 
-      <div className={cn("space-y-4 p-4", compact && "max-h-[500px] overflow-auto")}>
-        <div>
-          <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
-            Interpreted Goal
-          </p>
-          <p className="text-sm leading-relaxed">{task.interpretedGoal}</p>
-        </div>
-
-        <ProgressList task={task} />
-
+      <div className="space-y-4 p-4">
         {isWorking && (
-          <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Working across available chat context...
-          </div>
-        )}
-
-        {task.status === "failed" && (
-          <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-            <span>{task.error || task.resultSummary}</span>
-          </div>
-        )}
-
-        <div>
-          <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
-            Result
-          </p>
-          <div className="text-sm leading-relaxed">
-            <MarkdownContent content={task.resultSummary} />
-          </div>
-        </div>
-
-        {task.artifact && <ArtifactPanel artifact={task.artifact} />}
-
-        {task.openLoops && task.openLoops.length > 0 && (
-          <div>
-            <p className="mb-2 text-[10px] font-medium uppercase text-muted-foreground">
-              Open Loops Brief
-            </p>
-            <div className="space-y-2">
-              {task.openLoops.map((item) => (
-                <OpenLoopItem
-                  key={item.id}
-                  item={item}
-                  onOpenChat={onOpenChat}
-                  onInsertPrompt={onInsertPrompt}
-                />
-              ))}
+          <>
+            <ProgressList task={task} />
+            <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Reviewing available chat context...
             </div>
-          </div>
+          </>
         )}
 
-        <div>
-          <div className="mb-2 flex items-center gap-2">
-            <Search className="h-3.5 w-3.5 text-muted-foreground" />
-            <p className="text-[10px] font-medium uppercase text-muted-foreground">
-              Sources Used
-            </p>
-            <span className="text-[10px] text-muted-foreground">
-              {task.reviewedChatCount} reviewed
-            </span>
-          </div>
-          <SourceList sources={task.sources} onOpenChat={onOpenChat} />
-        </div>
+        {!isWorking && (
+          <>
+            <div className="rounded-lg bg-muted/30 px-3 py-2">
+              <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+                Interpreted Goal
+              </p>
+              <p className="text-sm leading-relaxed">{task.interpretedGoal}</p>
+            </div>
 
-        {task.missingInfo && task.missingInfo.length > 0 && (
-          <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
-            <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
-              Missing or Ambiguous
-            </p>
-            <ul className="space-y-1 text-xs text-muted-foreground">
-              {task.missingInfo.map((item) => (
-                <li key={item}>- {item}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+            {task.status === "failed" && (
+              <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{task.error || task.resultSummary}</span>
+              </div>
+            )}
 
-        <ProposedActions
-          actions={task.proposedActions}
-          artifact={task.artifact}
-          onOpenChat={onOpenChat}
-          onInsertPrompt={onInsertPrompt}
-        />
+            <div>
+              <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+                Result
+              </p>
+              <div className="text-sm leading-relaxed">
+                <MarkdownContent content={task.resultSummary} />
+              </div>
+            </div>
 
-        {onFollowUp && (
-          <form onSubmit={handleFollowUp} className="flex items-end gap-2 border-t border-border/70 pt-3">
-            <textarea
-              value={followUp}
-              onChange={(event) => setFollowUp(event.target.value)}
-              placeholder="Follow up with Assistant..."
-              rows={1}
-              className="min-h-9 flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            {task.artifact && <ArtifactPanel artifact={task.artifact} />}
+            {renderArtifactActions()}
+            {task.artifact && showArtifactPreview && (
+              <ArtifactPreview artifact={task.artifact} />
+            )}
+
+            {task.openLoops && task.openLoops.length > 0 && (
+              <div>
+                <p className="mb-2 text-[10px] font-medium uppercase text-muted-foreground">
+                  Open Loops Brief
+                </p>
+                <div className="space-y-2">
+                  {task.openLoops.map((item) => (
+                    <OpenLoopItem
+                      key={item.id}
+                      item={item}
+                      onOpenChat={onOpenChat}
+                      onInsertPrompt={onInsertPrompt}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <div className="mb-2 flex items-center gap-2">
+                <Search className="h-3.5 w-3.5 text-muted-foreground" />
+                <p className="text-[10px] font-medium uppercase text-muted-foreground">
+                  Sources Used
+                </p>
+                <span className="text-[10px] text-muted-foreground">
+                  {task.reviewedChatCount} reviewed
+                </span>
+              </div>
+              <SourceList sources={task.sources} onOpenChat={onOpenChat} />
+            </div>
+
+            {task.missingInfo && task.missingInfo.length > 0 && (
+              <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+                <p className="mb-1 text-[10px] font-medium uppercase text-muted-foreground">
+                  Missing or Ambiguous
+                </p>
+                <ul className="space-y-1 text-xs text-muted-foreground">
+                  {task.missingInfo.map((item) => (
+                    <li key={item}>- {item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <ProposedActions
+              actions={task.proposedActions}
+              artifact={task.artifact}
+              onOpenChat={onOpenChat}
+              onInsertPrompt={onInsertPrompt}
             />
-            <Button type="submit" size="sm" disabled={!followUp.trim()}>
-              Send
-            </Button>
-          </form>
-        )}
 
-        {onClose && !compact && (
-          <div className="flex justify-end border-t border-border/70 pt-3">
-            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
-              Resume chat
-            </Button>
-          </div>
+            {followUpForm}
+
+            {onClose && (
+              <div className="flex justify-end border-t border-border/70 pt-3">
+                <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                  Resume chat
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/lib/assistant/artifacts.ts
+++ b/lib/assistant/artifacts.ts
@@ -18,6 +18,10 @@ export function rowsToCsv<T extends object>(headers: string[], rows: T[]): strin
   return lines.join("\n")
 }
 
+export function sanitizeArtifactContent(content: string): string {
+  return content.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+}
+
 export function makeAssistantArtifact(args: {
   kind: AssistantArtifactKind
   filename: string
@@ -31,7 +35,8 @@ export function makeAssistantArtifact(args: {
     html: "text/html;charset=utf-8",
   }
 
-  const byteCount = new TextEncoder().encode(args.content).length
+  const content = sanitizeArtifactContent(args.content)
+  const byteCount = new TextEncoder().encode(content).length
   const sizeLabel =
     byteCount < 1024
       ? `${byteCount} B`
@@ -41,7 +46,7 @@ export function makeAssistantArtifact(args: {
     kind: args.kind,
     filename: args.filename,
     mimeType: mimeTypeByKind[args.kind],
-    content: args.content,
+    content,
     rowCount: args.rowCount,
     sizeLabel,
   }

--- a/lib/assistant/docx.ts
+++ b/lib/assistant/docx.ts
@@ -1,0 +1,318 @@
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+interface ZipEntry {
+  name: string
+  data: Uint8Array
+}
+
+interface ParsedTable {
+  headers: string[]
+  rows: string[][]
+  nextIndex: number
+}
+
+const encoder = new TextEncoder()
+
+const CRC_TABLE = new Uint32Array(256)
+for (let index = 0; index < 256; index++) {
+  let value = index
+  for (let bit = 0; bit < 8; bit++) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+  }
+  CRC_TABLE[index] = value >>> 0
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+function stripMarkdownInline(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/\\\|/g, "|")
+    .trim()
+}
+
+function paragraphXml(
+  text: string,
+  options: { heading?: 1 | 2; bullet?: boolean; italic?: boolean } = {}
+): string {
+  const size = options.heading === 1 ? "32" : options.heading === 2 ? "26" : "22"
+  const spacingAfter = options.heading ? "180" : "120"
+  const runProps = [
+    options.heading ? "<w:b/>" : "",
+    options.italic ? "<w:i/>" : "",
+    `<w:sz w:val="${size}"/>`,
+  ].join("")
+  const paragraphProps = [
+    `<w:spacing w:after="${spacingAfter}" w:line="276" w:lineRule="auto"/>`,
+    options.bullet ? '<w:ind w:left="360" w:hanging="180"/>' : "",
+  ].join("")
+  const prefix = options.bullet ? "• " : ""
+
+  return [
+    "<w:p>",
+    `<w:pPr>${paragraphProps}</w:pPr>`,
+    `<w:r><w:rPr>${runProps}</w:rPr><w:t xml:space="preserve">${xmlEscape(
+      `${prefix}${stripMarkdownInline(text)}`
+    )}</w:t></w:r>`,
+    "</w:p>",
+  ].join("")
+}
+
+function parseTableCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => stripMarkdownInline(cell))
+}
+
+function isTableSeparator(line: string): boolean {
+  return /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(line)
+}
+
+function parseTable(lines: string[], startIndex: number): ParsedTable | null {
+  if (!lines[startIndex]?.trim().startsWith("|")) return null
+  if (!isTableSeparator(lines[startIndex + 1] || "")) return null
+
+  const headers = parseTableCells(lines[startIndex])
+  const rows: string[][] = []
+  let nextIndex = startIndex + 2
+
+  while (lines[nextIndex]?.trim().startsWith("|")) {
+    rows.push(parseTableCells(lines[nextIndex]))
+    nextIndex++
+  }
+
+  return { headers, rows, nextIndex }
+}
+
+function tableCellXml(value: string, isHeader: boolean): string {
+  const runProps = isHeader ? "<w:b/><w:sz w:val=\"20\"/>" : "<w:sz w:val=\"20\"/>"
+
+  return [
+    "<w:tc>",
+    '<w:tcPr><w:tcW w:w="0" w:type="auto"/><w:tcMar><w:top w:w="80" w:type="dxa"/><w:left w:w="100" w:type="dxa"/><w:bottom w:w="80" w:type="dxa"/><w:right w:w="100" w:type="dxa"/></w:tcMar></w:tcPr>',
+    `<w:p><w:r><w:rPr>${runProps}</w:rPr><w:t xml:space="preserve">${xmlEscape(
+      stripMarkdownInline(value)
+    )}</w:t></w:r></w:p>`,
+    "</w:tc>",
+  ].join("")
+}
+
+function tableXml(headers: string[], rows: string[][]): string {
+  const border =
+    '<w:tblBorders><w:top w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/><w:left w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/><w:bottom w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/><w:right w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/><w:insideH w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/><w:insideV w:val="single" w:sz="4" w:space="0" w:color="D9DEE3"/></w:tblBorders>'
+  const headerRow = `<w:tr>${headers.map((cell) => tableCellXml(cell, true)).join("")}</w:tr>`
+  const bodyRows = rows
+    .map((row) => {
+      const cells = headers.map((_, index) => row[index] || "")
+      return `<w:tr>${cells.map((cell) => tableCellXml(cell, false)).join("")}</w:tr>`
+    })
+    .join("")
+
+  return [
+    "<w:tbl>",
+    `<w:tblPr><w:tblW w:w="0" w:type="auto"/>${border}</w:tblPr>`,
+    headerRow,
+    bodyRows,
+    "</w:tbl>",
+    paragraphXml(""),
+  ].join("")
+}
+
+function markdownToDocumentXml(markdown: string): string {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n")
+  const body: string[] = []
+
+  for (let index = 0; index < lines.length; index++) {
+    const raw = lines[index]
+    const line = raw.trim()
+    if (!line) continue
+
+    const table = parseTable(lines, index)
+    if (table) {
+      body.push(tableXml(table.headers, table.rows))
+      index = table.nextIndex - 1
+      continue
+    }
+
+    if (line.startsWith("# ")) {
+      body.push(paragraphXml(line.slice(2), { heading: 1 }))
+    } else if (line.startsWith("## ")) {
+      body.push(paragraphXml(line.slice(3), { heading: 2 }))
+    } else if (line.startsWith("- ")) {
+      body.push(paragraphXml(line.slice(2), { bullet: true }))
+    } else {
+      body.push(paragraphXml(line, { italic: /^_.*_$/.test(line) }))
+    }
+  }
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+    "<w:body>",
+    body.join(""),
+    '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1080" w:right="1080" w:bottom="1080" w:left="1080" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr>',
+    "</w:body>",
+    "</w:document>",
+  ].join("")
+}
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff
+  for (const byte of data) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function writeUint16(view: DataView, offset: number, value: number): void {
+  view.setUint16(offset, value, true)
+}
+
+function writeUint32(view: DataView, offset: number, value: number): void {
+  view.setUint32(offset, value, true)
+}
+
+function dosDateTime(date: Date): { time: number; date: number } {
+  const year = Math.max(1980, date.getFullYear())
+  return {
+    time: (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+  }
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+  for (const part of parts) {
+    result.set(part, offset)
+    offset += part.length
+  }
+  return result
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  return buffer
+}
+
+function zip(entries: ZipEntry[]): Blob {
+  const now = dosDateTime(new Date())
+  const localParts: Uint8Array[] = []
+  const centralParts: Uint8Array[] = []
+  let offset = 0
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name)
+    const crc = crc32(entry.data)
+    const size = entry.data.length
+
+    const localHeader = new Uint8Array(30 + nameBytes.length)
+    const localView = new DataView(localHeader.buffer)
+    writeUint32(localView, 0, 0x04034b50)
+    writeUint16(localView, 4, 20)
+    writeUint16(localView, 6, 0)
+    writeUint16(localView, 8, 0)
+    writeUint16(localView, 10, now.time)
+    writeUint16(localView, 12, now.date)
+    writeUint32(localView, 14, crc)
+    writeUint32(localView, 18, size)
+    writeUint32(localView, 22, size)
+    writeUint16(localView, 26, nameBytes.length)
+    writeUint16(localView, 28, 0)
+    localHeader.set(nameBytes, 30)
+    localParts.push(localHeader, entry.data)
+
+    const centralHeader = new Uint8Array(46 + nameBytes.length)
+    const centralView = new DataView(centralHeader.buffer)
+    writeUint32(centralView, 0, 0x02014b50)
+    writeUint16(centralView, 4, 20)
+    writeUint16(centralView, 6, 20)
+    writeUint16(centralView, 8, 0)
+    writeUint16(centralView, 10, 0)
+    writeUint16(centralView, 12, now.time)
+    writeUint16(centralView, 14, now.date)
+    writeUint32(centralView, 16, crc)
+    writeUint32(centralView, 20, size)
+    writeUint32(centralView, 24, size)
+    writeUint16(centralView, 28, nameBytes.length)
+    writeUint16(centralView, 30, 0)
+    writeUint16(centralView, 32, 0)
+    writeUint16(centralView, 34, 0)
+    writeUint16(centralView, 36, 0)
+    writeUint32(centralView, 38, 0)
+    writeUint32(centralView, 42, offset)
+    centralHeader.set(nameBytes, 46)
+    centralParts.push(centralHeader)
+
+    offset += localHeader.length + entry.data.length
+  }
+
+  const centralDirectory = concat(centralParts)
+  const end = new Uint8Array(22)
+  const endView = new DataView(end.buffer)
+  writeUint32(endView, 0, 0x06054b50)
+  writeUint16(endView, 4, 0)
+  writeUint16(endView, 6, 0)
+  writeUint16(endView, 8, entries.length)
+  writeUint16(endView, 10, entries.length)
+  writeUint32(endView, 12, centralDirectory.length)
+  writeUint32(endView, 16, offset)
+  writeUint16(endView, 20, 0)
+
+  return new Blob([toArrayBuffer(concat([...localParts, centralDirectory, end]))], {
+    type: DOCX_MIME,
+  })
+}
+
+function textEntry(name: string, content: string): ZipEntry {
+  return { name, data: encoder.encode(content) }
+}
+
+export function docxFilenameFor(filename: string): string {
+  return filename.replace(/\.[^.]+$/, "") + ".docx"
+}
+
+export function makeDocxBlobFromMarkdown(markdown: string, title: string): Blob {
+  const createdAt = new Date().toISOString()
+  const documentXml = markdownToDocumentXml(markdown)
+
+  return zip([
+    textEntry(
+      "[Content_Types].xml",
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/><Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/></Types>'
+    ),
+    textEntry(
+      "_rels/.rels",
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/></Relationships>'
+    ),
+    textEntry("word/document.xml", documentXml),
+    textEntry(
+      "docProps/core.xml",
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title>${xmlEscape(
+        title
+      )}</dc:title><dc:creator>Assistant demo</dc:creator><cp:lastModifiedBy>Assistant demo</cp:lastModifiedBy><dcterms:created xsi:type="dcterms:W3CDTF">${createdAt}</dcterms:created><dcterms:modified xsi:type="dcterms:W3CDTF">${createdAt}</dcterms:modified></cp:coreProperties>`
+    ),
+    textEntry(
+      "docProps/app.xml",
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"><Application>Assistant demo</Application></Properties>'
+    ),
+  ])
+}

--- a/lib/assistant/generation.ts
+++ b/lib/assistant/generation.ts
@@ -14,6 +14,15 @@ const AssistantDocumentSectionSchema = z.object({
     .describe("Specific, non-repetitive bullets grounded in the provided chat context"),
 })
 
+const AssistantDocumentTableSchema = z.object({
+  title: z.string().describe("Short table title"),
+  headers: z.array(z.string()).min(2).max(5).describe("Concise table headers"),
+  rows: z
+    .array(z.array(z.string()).min(2).max(5))
+    .max(8)
+    .describe("Rows grounded only in provided source context"),
+})
+
 const AssistantDocumentSourceSchema = z.object({
   chatId: z.string().describe("Source chat ID exactly as provided"),
   title: z.string().describe("Source chat title exactly as provided"),
@@ -26,7 +35,15 @@ const AssistantDocumentSchema = z.object({
   overview: z
     .string()
     .describe("Brief synthesis of what the provided chats support. Do not invent facts."),
+  keyTakeaways: z
+    .array(z.string())
+    .max(5)
+    .describe("The most important user-facing takeaways from the provided chat context"),
   sections: z.array(AssistantDocumentSectionSchema).min(1).max(8),
+  tables: z
+    .array(AssistantDocumentTableSchema)
+    .max(3)
+    .describe("Optional compact tables for plans, inventories, references, or checklists"),
   sourcesUsed: z.array(AssistantDocumentSourceSchema).max(8),
   missingOrAmbiguous: z
     .array(z.string())
@@ -88,6 +105,26 @@ function renderMarkdownDocument(parsed: z.infer<typeof AssistantDocumentSchema>)
     "",
   ]
 
+  if (parsed.keyTakeaways.length > 0) {
+    lines.push("## Key Takeaways")
+    for (const takeaway of parsed.keyTakeaways) {
+      lines.push(`- ${takeaway}`)
+    }
+    lines.push("")
+  }
+
+  for (const table of parsed.tables) {
+    const columnCount = table.headers.length
+    lines.push(`## ${table.title}`)
+    lines.push(`| ${table.headers.join(" | ")} |`)
+    lines.push(`| ${table.headers.map(() => "---").join(" | ")} |`)
+    for (const row of table.rows) {
+      const cells = Array.from({ length: columnCount }, (_, index) => row[index] || "")
+      lines.push(`| ${cells.map((cell) => cell.replace(/\|/g, "\\|")).join(" | ")} |`)
+    }
+    lines.push("")
+  }
+
   for (const section of parsed.sections) {
     lines.push(`## ${section.heading}`)
     for (const bullet of section.bullets) {
@@ -145,6 +182,10 @@ ${context}
 Create the downloadable document artifact. Use only the chat context above.
 Requirements:
 - Synthesize across chats instead of repeating the same source snippet.
+- Produce a finished user-facing artifact, not a recap of the retrieval process.
+- Start with 3-5 key takeaways when the context supports them.
+- If the request asks for a plan, include a practical sequence, checkpoints, and what to do first.
+- Use compact tables for plans, reference overviews, inventories, or checklists when they make the artifact easier to use.
 - Preserve exact facts, dates, numbers, units, and claims only when present.
 - Leave gaps explicit in missingOrAmbiguous.
 - Do not include generic advice unless it is clearly grounded in the provided chats.
@@ -163,13 +204,19 @@ Requirements:
     if (!parsed) return null
 
     const content = renderMarkdownDocument(parsed)
+    const overview = parsed.overview.replace(/\s+/g, " ").trim()
+    const summaryParts = [
+      `Created "${parsed.title}" from ${args.sources.length} source chat${args.sources.length === 1 ? "" : "s"}.`,
+      overview ? overview.slice(0, 260) : "",
+    ].filter(Boolean)
+
     return {
       artifact: makeAssistantArtifact({
         kind: "markdown",
         filename: `${slugifyFilenamePart(parsed.title || args.title)}.md`,
         content,
       }),
-      summary: `I synthesized a downloadable ${parsed.title.toLowerCase()} from ${args.sources.length} source chat${args.sources.length === 1 ? "" : "s"}.`,
+      summary: summaryParts.join("\n\n"),
       missingInfo: parsed.missingOrAmbiguous,
     }
   } catch (error) {

--- a/lib/assistant/retrieval.ts
+++ b/lib/assistant/retrieval.ts
@@ -110,6 +110,31 @@ const DOMAIN_TERMS: Record<string, string[]> = {
     "prep",
     "leadership",
   ],
+  golf: [
+    "golf",
+    "golfer",
+    "swing",
+    "club",
+    "driver",
+    "iron",
+    "speed",
+    "mobility",
+    "rotator",
+    "shoulder",
+    "performance",
+    "training",
+  ],
+  nutrition: [
+    "nutrition",
+    "diet",
+    "protein",
+    "carbs",
+    "calories",
+    "meals",
+    "recovery",
+    "sleep",
+    "bodyweight",
+  ],
 }
 
 const OPEN_LOOP_TERMS = [
@@ -246,7 +271,12 @@ function classifyTaskKind(request: string): AssistantTaskKind {
     lower.includes("curriculum") ||
     lower.includes("study guide") ||
     lower.includes("brief") ||
-    lower.includes("document")
+    lower.includes("document") ||
+    lower.includes("plan") ||
+    lower.includes("overview") ||
+    lower.includes("reference") ||
+    lower.includes("synthesize") ||
+    lower.includes("compile")
   ) {
     return "cross_chat_artifact"
   }
@@ -271,6 +301,15 @@ function interpretedGoalFor(kind: AssistantTaskKind, request: string): string {
   }
   if (kind === "cross_chat_artifact" && lower.includes("curriculum")) {
     return "Collect relevant learning chats and turn the available context into a downloadable curriculum document."
+  }
+  if (kind === "cross_chat_artifact" && lower.includes("plan")) {
+    return "Synthesize relevant chats into a practical downloadable plan with evidence, priorities, and open questions."
+  }
+  if (
+    kind === "cross_chat_artifact" &&
+    (lower.includes("overview") || lower.includes("reference") || lower.includes("personal numbers"))
+  ) {
+    return "Create a concise reference artifact from the user's stated details across relevant chats."
   }
   if (kind === "cross_chat_artifact") {
     return "Collect relevant chats, organize the available context, and generate a downloadable artifact."
@@ -487,6 +526,10 @@ function buildLiftingArtifact(request: string, scored: ScoredThread[]): {
 function inferDocumentTitle(request: string): string {
   const lower = request.toLowerCase()
   if (lower.includes("calculus")) return "Calculus Curriculum"
+  if (lower.includes("golf") && lower.includes("plan")) return "6-8 Week Golf Performance Plan"
+  if (lower.includes("personal") && (lower.includes("number") || lower.includes("info"))) {
+    return "Personal Numbers and Reference Overview"
+  }
   if (lower.includes("product") || lower.includes("pm ")) return "Product Management Study Guide"
   if (lower.includes("brief")) return "Assistant Brief"
   return "Assistant Workspace Document"
@@ -792,8 +835,20 @@ export async function createAssistantTaskResult(args: {
   } | null
 }): Promise<AssistantTaskResult> {
   const now = Date.now()
-  const taskKind = classifyTaskKind(args.request)
-  const interpretedGoal = interpretedGoalFor(taskKind, args.request)
+  const initialKind = classifyTaskKind(args.request)
+  const taskKind =
+    initialKind === "clarification" && args.previousTask ? args.previousTask.taskKind : initialKind
+  const effectiveRequest = args.previousTask
+    ? [
+        `Previous Assistant request: ${args.previousTask.requestText}`,
+        `Previous interpreted goal: ${args.previousTask.interpretedGoal}`,
+        `Previous result summary: ${args.previousTask.resultSummary}`,
+        `Follow-up request: ${args.request}`,
+      ].join("\n")
+    : args.request
+  const interpretedGoal = args.previousTask
+    ? `Continue the previous Assistant task and apply this follow-up: ${args.request}`
+    : interpretedGoalFor(taskKind, args.request)
   const progress: AssistantTaskStatus[] = ["queued", "interpreting", "searching", "reviewing"]
 
   if (taskKind === "open_loops" || taskKind === "codex_prompt_draft") {
@@ -819,9 +874,9 @@ export async function createAssistantTaskResult(args: {
     }
   }
 
-  const scored = selectRelevantThreads(args.request, args.threads)
+  const scored = selectRelevantThreads(effectiveRequest, args.threads)
   const sources = sourcesFromScored(scored)
-  const lower = args.request.toLowerCase()
+  const lower = effectiveRequest.toLowerCase()
   let artifactResult =
     lower.includes("lifting") || lower.includes("spreadsheet") || lower.includes("csv")
       ? buildLiftingArtifact(args.request, scored)
@@ -832,7 +887,7 @@ export async function createAssistantTaskResult(args: {
     !(lower.includes("lifting") || lower.includes("spreadsheet") || lower.includes("csv"))
   ) {
     const modelArtifact = await generateAssistantDocumentArtifact({
-      request: args.request,
+      request: effectiveRequest,
       interpretedGoal,
       title: inferDocumentTitle(args.request),
       sources: scored.slice(0, 8).map((item) => ({

--- a/lib/openai/client.ts
+++ b/lib/openai/client.ts
@@ -141,7 +141,7 @@ type TextVerbosity = "low" | "medium" | "high"
 const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
   chat_fast: "low",
   chat_deep: "low",
-  summarize: "minimal", // Use minimal for fastest summarization
+  summarize: "low",
   intent: "low",
   stacks: "low",
   finder: "low",
@@ -153,7 +153,7 @@ const REASONING_EFFORT: Record<RequestKind, ReasoningEffort> = {
  * Fallback reasoning effort if the primary is rejected by the API
  */
 const REASONING_EFFORT_FALLBACK: Partial<Record<RequestKind, ReasoningEffort>> = {
-  summarize: "low", // Fall back to "low" if "minimal" is rejected
+  summarize: "low", // Supports env overrides such as minimal with a safe fallback
   assistant: "low",
 }
 
@@ -430,7 +430,7 @@ export async function createTextResponse(options: {
  * Create a summarization response with timeout and reasoning effort fallback
  * 
  * This function is optimized for speed:
- * - Uses "minimal" reasoning effort (falls back to "low" if rejected)
+ * - Uses "low" reasoning effort by default
  * - Supports abort signal for timeout
  * - Always uses store: false (summarization shouldn't affect chaining state)
  * - Includes instrumentation logging for debugging
@@ -475,7 +475,7 @@ export async function createSummarizeResponse(options: {
   }
 
   try {
-    // Try with primary reasoning effort (minimal)
+    // Try with the configured reasoning effort.
     const response = await attemptRequest(reasoningUsed)
     const durationMs = Date.now() - startTime
 
@@ -510,6 +510,7 @@ export async function createSummarizeResponse(options: {
     // Check if the API rejected the configured reasoning effort - retry with fallback
     if (
       config.reasoningFallback &&
+      config.reasoningFallback !== reasoningUsed &&
       error instanceof OpenAI.APIError &&
       isReasoningUnsupportedError(error)
     ) {

--- a/lib/store/store.ts
+++ b/lib/store/store.ts
@@ -328,6 +328,15 @@ class MemoryStore implements ChatStore {
     return thread
   }
 
+  async upsertThread(demoUid: string, thread: StoredChatThread): Promise<void> {
+    logOp("Memory", "upsertThread", demoUid, `threadId=${thread.id.slice(0, 8)}`)
+    const userThreads = this.getOrCreateUserThreads(demoUid)
+    userThreads.set(thread.id, {
+      ...thread,
+      messages: [...thread.messages],
+    })
+  }
+
   async appendMessage(
     demoUid: string,
     threadId: string,
@@ -456,6 +465,20 @@ class ResilientRedisStore implements ChatStore {
     return false
   }
 
+  private async mirrorRedisThreadToFallback(demoUid: string, threadId: string): Promise<void> {
+    try {
+      const thread = await this.redis.getThread(demoUid, threadId)
+      if (thread) {
+        await this.fallback.upsertThread(demoUid, thread)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn(
+        `[ChatStore:Resilient] Failed to mirror Redis thread to fallback: ${message}`
+      )
+    }
+  }
+
   /**
    * Try a Redis operation; on failure, fall back to memory store.
    * For read operations, the memory store result is returned (may be empty on first fallback).
@@ -524,8 +547,7 @@ class ResilientRedisStore implements ChatStore {
       "appendMessage",
       async () => {
         await this.redis.appendMessage(demoUid, threadId, message)
-        // Mirror to fallback
-        await this.fallback.appendMessage(demoUid, threadId, message)
+        await this.mirrorRedisThreadToFallback(demoUid, threadId)
       },
       () => this.fallback.appendMessage(demoUid, threadId, message),
       true,
@@ -537,8 +559,7 @@ class ResilientRedisStore implements ChatStore {
       "updateThread",
       async () => {
         await this.redis.updateThread(demoUid, threadId, partial)
-        // Mirror to fallback
-        await this.fallback.updateThread(demoUid, threadId, partial)
+        await this.mirrorRedisThreadToFallback(demoUid, threadId)
       },
       () => this.fallback.updateThread(demoUid, threadId, partial),
       true,


### PR DESCRIPTION
## Summary
- Simplifies the Assistant popup into a cleaner demo surface with three curated task chips and a smaller sample-workspace affordance.
- Refines inline `@assistant` cards so running states do not show premature empty-source failures, ready states can preview generated artifacts, and inline artifacts can be included in hidden chat context.
- Improves Assistant output quality with richer document artifact prompting, key takeaways/tables, more specific summaries, control-character sanitization, and better golf/nutrition retrieval terms.
- Hardens demo reliability by preserving Assistant follow-up context in the API, making unexpected Assistant route failures visible as non-2xx, avoiding known title-summary reasoning retries, and hydrating the in-memory fallback from Redis after writes.

## Validation
- `npm run lint` passes with existing warnings only.
- `npm run build` passes.
- Production-mode Assistant API smoke test returned `ready cross_chat_artifact sources=1 artifact=6-8-week-golf-performance-plan.md`.

## Notes
- No external integrations or durable Assistant jobs were added.
- The inline "Include in chat context" action ingests context behind the scenes and does not add visible chat clutter.
