### PR TITLE
Interlace design pass: identity-driven restyle, 'Chat, rewoven' branding

### DIFF
--- a/app/demos/history/page.tsx
+++ b/app/demos/history/page.tsx
@@ -853,12 +853,12 @@ function HistoryDemoContent() {
                                   message.role === "user"
                                     ? "bg-primary text-primary-foreground rounded-br-md"
                                     : message.role === "context"
-                                    ? "bg-amber-500/10 text-foreground border border-amber-500/20 rounded-bl-md"
+                                    ? "bg-warning/10 text-foreground border border-warning/20 rounded-bl-md"
                                     : "bg-card text-card-foreground border border-border rounded-bl-md"
                                 )}
                               >
                                 {message.role === "context" && (
-                                  <div className="text-[10px] text-amber-600 dark:text-amber-400 font-medium mb-1">
+                                  <div className="text-[10px] uppercase tracking-[0.08em] text-warning-foreground dark:text-warning font-medium mb-1">
                                     CONTEXT
                                   </div>
                                 )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,49 +2,105 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * ── Interlace token system ──────────────────────────────────────────────
+ * One material family: undyed linen (neutrals) + a single dyed thread (accent).
+ *
+ * Light — "undyed linen": warm off-white ground, warm surface steps, warm
+ *   near-black ink. No pure #fff.
+ * Dark  — "loom at night": warm charcoal (hue ~30, NOT blue-gray zinc),
+ *   warm off-white ink. No pure #000.
+ *
+ * Values are `H S% L%` triples consumed via hsl(var(--x)). Existing shadcn
+ * token NAMES are preserved so every component keeps working; only VALUES
+ * are retuned. A few new tokens are added (documented inline).
+ *
+ * Note: shadcn's --accent / --accent-foreground are the neutral *hover
+ * surface* (ghost buttons, dropdown items) — NOT the brand accent. The brand
+ * accent (the dyed thread) is --primary and --ring.
+ */
+
 :root {
-  --background: 0 0% 100%;
-  --foreground: 240 10% 3.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
-  --primary: 240 5.9% 10%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
-  --muted: 240 4.8% 95.9%;
-  --muted-foreground: 240 3.8% 46.1%;
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 5.9% 90%;
-  --input: 240 5.9% 90%;
-  --ring: 240 5.9% 10%;
+  /* Neutrals — undyed linen (warm hue ~36–42) */
+  --background: 40 33% 97%; /* warm off-white paper */
+  --foreground: 30 12% 16%; /* warm near-black ink */
+
+  --card: 42 45% 98%; /* raised surface — a hair brighter than ground */
+  --card-foreground: 30 12% 16%;
+  --popover: 42 45% 98%;
+  --popover-foreground: 30 12% 16%;
+
+  --secondary: 38 24% 93%; /* tonal surface step (secondary buttons) */
+  --secondary-foreground: 30 12% 20%;
+
+  --muted: 36 22% 93%; /* muted surface (assistant bubble, quiet fills) */
+  --muted-foreground: 34 8% 44%;
+
+  --accent: 36 24% 92%; /* NEUTRAL hover surface (ghost/dropdown hover) */
+  --accent-foreground: 30 12% 20%;
+
+  /* The dyed thread — desaturated terracotta / madder. Brand accent. */
+  --primary: 12 46% 46%;
+  --primary-foreground: 40 40% 97%; /* warm near-white; AA ~4.8:1 on primary */
+
+  /* Signal colors — same-room desaturated versions (feature components
+     migrate off raw Tailwind emerald/amber/purple onto these later). */
+  --success: 145 25% 36%; /* sage — merge / applied */
+  --success-foreground: 40 40% 97%;
+  --warning: 40 68% 52%; /* flax amber — ready / pending (dark ink on top) */
+  --warning-foreground: 33 35% 16%;
+  --destructive: 6 54% 43%; /* muted brick — errors */
+  --destructive-foreground: 40 40% 97%;
+
+  --border: 36 18% 87%; /* subtle warm separator */
+  --input: 36 18% 85%;
+  --ring: 12 46% 46%; /* focus = the dyed thread */
+
+  /* New tokens (Interlace-specific) */
+  --surface-sunken: 38 20% 93%; /* recessed regions: sidebar tone-shift */
+  --thread: 12 46% 46%; /* the woven-in 2px accent edge on weft moments */
+  --accent-soft: 12 40% 92%; /* low-chroma terracotta wash (active context fills) */
+
   --radius: 0.625rem;
 }
 
 .dark {
-  --background: 240 10% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
-  --primary-foreground: 240 5.9% 10%;
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 240 3.7% 15.9%;
-  --muted-foreground: 240 5% 64.9%;
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 3.7% 15.9%;
-  --input: 240 3.7% 15.9%;
-  --ring: 240 4.9% 83.9%;
+  /* Neutrals — loom at night (warm charcoal, hue ~30) */
+  --background: 30 8% 10%; /* warm charcoal ground */
+  --foreground: 40 20% 92%; /* warm off-white ink */
+
+  --card: 30 7% 13%; /* raised surface */
+  --card-foreground: 40 20% 92%;
+  --popover: 30 8% 12%;
+  --popover-foreground: 40 20% 92%;
+
+  --secondary: 30 6% 17%;
+  --secondary-foreground: 40 18% 90%;
+
+  --muted: 30 6% 16%;
+  --muted-foreground: 36 10% 62%;
+
+  --accent: 30 6% 18%; /* neutral hover surface */
+  --accent-foreground: 40 18% 90%;
+
+  /* Dyed thread lifts brighter against the dark ground */
+  --primary: 14 50% 62%;
+  --primary-foreground: 28 24% 12%; /* dark ink on light terracotta; AA ~5.6:1 */
+
+  --success: 145 30% 42%;
+  --success-foreground: 40 30% 96%;
+  --warning: 40 60% 55%;
+  --warning-foreground: 28 30% 12%;
+  --destructive: 8 52% 46%;
+  --destructive-foreground: 40 30% 96%;
+
+  --border: 34 8% 22%;
+  --input: 34 8% 24%;
+  --ring: 14 50% 62%;
+
+  --surface-sunken: 30 9% 8%;
+  --thread: 14 50% 62%;
+  --accent-soft: 14 35% 22%;
 }
 
 @theme inline {
@@ -64,12 +120,22 @@
   --color-accent-foreground: hsl(var(--accent-foreground));
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-success: hsl(var(--success));
+  --color-success-foreground: hsl(var(--success-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
+  --color-surface-sunken: hsl(var(--surface-sunken));
+  --color-thread: hsl(var(--thread));
+  --color-accent-soft: hsl(var(--accent-soft));
 
-  --font-sans: var(--font-sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  /* Type — three voices. next/font sets --ff-* on <html>; these theme tokens
+     generate the font-display / font-sans / font-mono utilities. */
+  --font-display: var(--ff-display), Georgia, "Times New Roman", serif;
+  --font-sans: var(--ff-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: var(--ff-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -84,57 +150,25 @@
 body {
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  font-family: var(--font-sans), system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
-/* Subtle gradient background */
-.app-background {
-  background:
-    linear-gradient(135deg, hsl(var(--background)) 0%, hsl(240 4.8% 95.9%) 50%, hsl(var(--background)) 100%);
-  min-height: 100vh;
+/* The display voice is opt-in and used sparingly (wordmark, empty-state title,
+   section headers). Tailwind also generates a `font-display` utility from the
+   theme token above; this explicit class carries the reading-optimized
+   feature settings. */
+.font-display {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-feature-settings: "liga" 1, "calt" 1;
+  letter-spacing: -0.01em;
 }
 
-.dark .app-background {
-  background:
-    linear-gradient(135deg, hsl(var(--background)) 0%, hsl(240 3.7% 8%) 50%, hsl(var(--background)) 100%);
-}
+/* ── Motion ──────────────────────────────────────────────────────────────
+   State communication only, never decoration. Timings kept in the taste
+   register (~0.2s color/state, ~0.3–0.4s visibility/layout). */
 
-/* Noise texture overlay */
-.noise-overlay::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.015;
-  pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-  z-index: 1;
-}
-
-.dark .noise-overlay::before {
-  opacity: 0.03;
-}
-
-/* App frame styling */
-.app-frame {
-  background: hsl(var(--card));
-  border-radius: var(--radius-xl);
-  box-shadow:
-    0 0 0 1px hsl(var(--border) / 0.5),
-    0 4px 6px -1px rgb(0 0 0 / 0.05),
-    0 10px 15px -3px rgb(0 0 0 / 0.05);
-}
-
-.dark .app-frame {
-  box-shadow:
-    0 0 0 1px hsl(var(--border) / 0.5),
-    0 4px 6px -1px rgb(0 0 0 / 0.2),
-    0 10px 15px -3px rgb(0 0 0 / 0.2);
-}
-
-/* Chat message animations */
+/* Chat message entrance */
 @keyframes message-in {
   from {
     opacity: 0;
@@ -147,10 +181,10 @@ body {
 }
 
 .animate-message-in {
-  animation: message-in 0.2s ease-out forwards;
+  animation: message-in 0.24s ease-out forwards;
 }
 
-/* Typing indicator animation */
+/* Typing indicator */
 @keyframes typing-dot {
   0%, 60%, 100% {
     opacity: 0.3;
@@ -174,7 +208,7 @@ body {
   animation-delay: 0.3s;
 }
 
-/* Chip/badge fade + scale animation */
+/* Chip / badge fade + scale (context events woven in) */
 @keyframes chip-in {
   from {
     opacity: 0;
@@ -190,7 +224,7 @@ body {
   animation: chip-in 0.25s ease-out forwards;
 }
 
-/* Shimmer animation for progress bars */
+/* Shimmer for progress surfaces */
 @keyframes shimmer {
   0% {
     transform: translateX(-100%);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,43 @@
 import type { Metadata } from "next"
+import { Fraunces, Public_Sans, IBM_Plex_Mono } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Nav } from "@/components/nav"
 import { Toaster } from "@/components/ui/sonner"
+import { APP_BADGE, APP_NAME, APP_TAGLINE } from "@/lib/branding"
 import "./globals.css"
 
+// Display — a characterful, composed serif for the wordmark, empty-state
+// title, and section headers. Fraunces reads warm and literate at UI-adjacent
+// sizes (this is a reading product); kept to 400–500 so display type feels
+// confident, not brutish.
+const fontDisplay = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  style: ["normal", "italic"],
+  variable: "--ff-display",
+  display: "swap",
+})
+
+// UI / body — a quiet humanist sans. Public Sans is exceptionally legible at
+// small UI sizes and carries no house/template signature.
+const fontSans = Public_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--ff-sans",
+  display: "swap",
+})
+
+// Mono — warm, humanist monospace for code, diffs, and artifact filenames.
+const fontMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--ff-mono",
+  display: "swap",
+})
+
 export const metadata: Metadata = {
-  title: "LLM Chat Demos",
-  description: "Product improvements to LLM chat interfaces",
+  title: `${APP_NAME} (${APP_BADGE})`,
+  description: APP_TAGLINE,
 }
 
 export default function RootLayout({
@@ -15,7 +46,11 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${fontDisplay.variable} ${fontSans.variable} ${fontMono.variable}`}
+    >
       <body className="font-sans antialiased">
         <ThemeProvider
           attribute="class"
@@ -23,17 +58,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="app-background noise-overlay min-h-screen">
-            <div className="relative z-10 min-h-screen flex flex-col">
-              <div className="mx-auto w-full max-w-7xl px-4 py-4 flex-1 flex flex-col">
-                <div className="app-frame flex-1 flex flex-col overflow-hidden">
-                  <Nav />
-                  <main className="flex-1 overflow-auto">
-                    {children}
-                  </main>
-                </div>
-              </div>
-            </div>
+          {/* De-framed: one full-bleed surface. Nav + main fill the viewport;
+              main owns its own scroll so page-level layouts can size to h-full. */}
+          <div className="flex h-screen flex-col bg-background text-foreground">
+            <Nav />
+            <main className="min-h-0 flex-1 overflow-auto">{children}</main>
           </div>
           <Toaster />
         </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -466,6 +466,18 @@ function UnifiedDemoContent() {
     toast.success("Prompt inserted")
   }
 
+  const handleSelectExamplePrompt = useCallback((prompt: string) => {
+    setInputValue(prompt)
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current
+      if (textarea) {
+        textarea.focus()
+        const end = textarea.value.length
+        textarea.setSelectionRange(end, end)
+      }
+    })
+  }, [])
+
   return (
     <TooltipProvider delayDuration={300}>
       <div className="flex h-full">
@@ -481,10 +493,10 @@ function UnifiedDemoContent() {
         <div className="flex-1 flex flex-col">
           <StorageWarningBanner className="m-2" />
 
-          <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border/40">
             <div className="flex items-center gap-2">
-              <Zap className="h-5 w-5 text-primary" />
-              <span className="font-medium">Unified Chat</span>
+              <Zap className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-medium text-muted-foreground">Unified Chat</span>
             </div>
             <AssistantLauncher
               onRunTask={assistant.runAssistantTask}
@@ -500,9 +512,9 @@ function UnifiedDemoContent() {
             className="flex-1 overflow-y-auto"
           >
             {!hasMessages && !isLoading && !hasFinderResults && !finder.finderPending ? (
-              <UnifiedEmptyState />
+              <UnifiedEmptyState onSelectPrompt={handleSelectExamplePrompt} />
             ) : (
-              <div className="p-4 space-y-4">
+              <div className="mx-auto w-full max-w-3xl px-4 py-6 space-y-4">
                 {messages.map((message) => {
                   if (message.isAssistantTaskCard && message.assistantTaskId) {
                     const task = assistant.assistantTasks[message.assistantTaskId]
@@ -550,7 +562,7 @@ function UnifiedDemoContent() {
 
                 {finder.finderPending && (
                   <div className="flex items-start">
-                    <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+                    <div className="bg-card border border-border/40 shadow-sm rounded-2xl rounded-bl-md px-4 py-3">
                       <div className="flex items-center gap-2">
                         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                         <span className="text-sm text-muted-foreground">Searching...</span>
@@ -588,9 +600,9 @@ function UnifiedDemoContent() {
             )}
           </div>
 
-          <div className="border-t border-border bg-card/50">
+          <div className="border-t border-border/40 bg-card/60">
             {docRead.attachedFile && (
-              <div className="px-4 pt-3 pb-0">
+              <div className="mx-auto w-full max-w-3xl px-4 pt-3 pb-0">
                 <FileAttachmentChip
                   filename={docRead.attachedFile.name}
                   isProcessing={docRead.isUploadingDoc}
@@ -600,15 +612,15 @@ function UnifiedDemoContent() {
             )}
 
             {docRead.isGeneratingTTS && (
-              <div className="px-4 pt-3 pb-0">
-                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-primary/10 border border-primary/20 text-sm">
+              <div className="mx-auto w-full max-w-3xl px-4 pt-3 pb-0">
+                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-accent-soft border-l-2 border-l-thread text-sm">
                   <Loader2 className="h-3.5 w-3.5 text-primary animate-spin" />
                   <span className="text-xs text-primary font-medium">Generating audio...</span>
                 </div>
               </div>
             )}
 
-            <div className="flex items-end gap-2 p-4">
+            <div className="mx-auto flex w-full max-w-3xl items-end gap-2 p-4">
               <input
                 ref={docRead.fileInputRef}
                 type="file"

--- a/components/assistant/assistant-popup.tsx
+++ b/components/assistant/assistant-popup.tsx
@@ -95,12 +95,12 @@ export function AssistantPopup({
   }
 
   return (
-    <div className="absolute right-0 top-full z-40 mt-2 w-[420px] overflow-hidden rounded-xl border border-border bg-card shadow-xl dark:shadow-black/30">
-      <div className="border-b border-border bg-teal-500/5 px-4 py-3">
+    <div className="absolute right-0 top-full z-40 mt-2 w-[420px] overflow-hidden rounded-xl border border-border border-l-2 border-l-thread bg-card shadow-[0_2px_16px_rgba(0,0,0,0.04)] dark:shadow-black/30">
+      <div className="border-b border-border/60 bg-accent-soft/40 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-teal-500/10">
-              <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-accent-soft">
+              <Compass className="h-4 w-4 text-primary" />
             </div>
             <div>
               <h2 className="text-sm font-semibold">Assistant</h2>

--- a/components/assistant/assistant-task-card.tsx
+++ b/components/assistant/assistant-task-card.tsx
@@ -46,12 +46,12 @@ const STATUS_LABELS: Record<AssistantTaskStatus, string> = {
 
 const STATUS_STYLES: Record<AssistantTaskStatus, string> = {
   queued: "bg-muted text-muted-foreground",
-  interpreting: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
-  searching: "bg-teal-500/10 text-teal-700 dark:text-teal-300",
-  reviewing: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
-  generating: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300",
-  ready: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-  failed: "bg-red-500/10 text-red-700 dark:text-red-300",
+  interpreting: "bg-accent-soft text-primary",
+  searching: "bg-accent-soft text-primary",
+  reviewing: "bg-accent-soft text-primary",
+  generating: "bg-accent-soft text-primary",
+  ready: "bg-success/15 text-success",
+  failed: "bg-destructive/15 text-destructive",
   no_results: "bg-muted text-muted-foreground",
 }
 
@@ -143,14 +143,14 @@ function WorkingState({
   compact?: boolean
 }) {
   return (
-    <div className="rounded-lg border border-teal-500/15 bg-teal-500/5 px-3 py-3">
+    <div className="rounded-lg border border-thread/25 bg-accent-soft/40 px-3 py-3">
       <div className="flex items-center gap-2 text-sm">
-        <Loader2 className="h-4 w-4 animate-spin text-teal-700 dark:text-teal-300" />
+        <Loader2 className="h-4 w-4 animate-spin text-primary" />
         <span className="font-medium">{WORKING_STEPS[stepIndex]}</span>
       </div>
-      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-background">
+      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full bg-teal-600 transition-all duration-500 dark:bg-teal-300"
+          className="h-full rounded-full bg-primary transition-all duration-500"
           style={{ width: `${((stepIndex + 1) / WORKING_STEPS.length) * 100}%` }}
         />
       </div>
@@ -159,12 +159,12 @@ function WorkingState({
           {WORKING_STEPS.map((step, index) => (
             <div key={step} className="flex min-w-0 items-center gap-1.5">
               {index < stepIndex ? (
-                <Check className="h-3 w-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                <Check className="h-3 w-3 shrink-0 text-success" />
               ) : (
                 <span
                   className={cn(
                     "h-2 w-2 shrink-0 rounded-full",
-                    index === stepIndex ? "bg-teal-600 dark:bg-teal-300" : "bg-muted-foreground/25"
+                    index === stepIndex ? "bg-primary" : "bg-muted-foreground/25"
                   )}
                 />
               )}
@@ -241,12 +241,12 @@ function ArtifactPanel({ artifact }: { artifact: AssistantArtifact }) {
   const supportsDocx = artifact.kind === "markdown"
 
   return (
-    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-3">
+    <div className="rounded-lg border border-border border-l-2 border-l-thread bg-surface-sunken px-3 py-3">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
-          <FileText className="h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-300" />
+          <FileText className="h-4 w-4 shrink-0 text-primary" />
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium">{artifact.filename}</p>
+            <p className="truncate font-mono text-sm font-medium">{artifact.filename}</p>
             <p className="text-xs text-muted-foreground">
               {artifact.kind.toUpperCase()}
               {artifact.rowCount ? ` - ${artifact.rowCount} rows` : ""}
@@ -609,12 +609,12 @@ export function AssistantTaskCard({
 
   if (compact) {
     return (
-      <div className="overflow-hidden rounded-lg border border-teal-500/20 bg-card shadow-sm">
+      <div className="overflow-hidden rounded-lg border border-border border-l-2 border-l-thread bg-card shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
         <div className="space-y-3 p-3">
           <div className="flex items-start justify-between gap-3">
             <div className="flex min-w-0 items-start gap-2.5">
-              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-teal-500/10">
-                <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+              <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-soft">
+                <Compass className="h-4 w-4 text-primary" />
               </div>
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -654,7 +654,7 @@ export function AssistantTaskCard({
           ) : (
             <>
               {task.status === "failed" && (
-                <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+                <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
                   <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                   <span>{task.error || task.resultSummary}</span>
                 </div>
@@ -710,14 +710,14 @@ export function AssistantTaskCard({
   return (
     <div
       className={cn(
-        "mx-auto w-full max-w-5xl overflow-hidden rounded-xl border border-teal-500/20 bg-card shadow-sm dark:shadow-md dark:shadow-black/20"
+        "mx-auto w-full max-w-5xl overflow-hidden rounded-xl border border-border border-l-2 border-l-thread bg-card shadow-[0_2px_16px_rgba(0,0,0,0.04)] dark:shadow-md dark:shadow-black/20"
       )}
     >
-      <div className="border-b border-border/70 bg-teal-500/5 px-4 py-3">
+      <div className="border-b border-border/60 bg-accent-soft/40 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-3">
-            <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-teal-500/10">
-              <Compass className="h-4 w-4 text-teal-700 dark:text-teal-300" />
+            <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent-soft">
+              <Compass className="h-4 w-4 text-primary" />
             </div>
             <div className="min-w-0">
               <div className="flex items-center gap-2">
@@ -727,7 +727,7 @@ export function AssistantTaskCard({
                 </span>
                 <span
                   className={cn(
-                    "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                    "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]",
                     STATUS_STYLES[task.status]
                   )}
                 >
@@ -768,7 +768,7 @@ export function AssistantTaskCard({
             </div>
 
             {task.status === "failed" && (
-              <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+              <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
                 <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>{task.error || task.resultSummary}</span>
               </div>

--- a/components/chat/audio-player.tsx
+++ b/components/chat/audio-player.tsx
@@ -350,7 +350,7 @@ export function AudioPlayer({
   return (
     <div
       className={cn(
-        "flex flex-col gap-2 p-3 rounded-xl bg-primary/5 border border-primary/10",
+        "flex flex-col gap-2 p-3 rounded-lg border-l-2 border-l-thread bg-surface-sunken",
         className
       )}
     >

--- a/components/chat/branch-chip.tsx
+++ b/components/chat/branch-chip.tsx
@@ -30,7 +30,7 @@ export function BranchChip({ branches, onOpenBranch }: BranchChipProps) {
           "transition-all duration-200 cursor-pointer",
           "border animate-chip-in",
           branch.mergedIntoMain
-            ? "bg-emerald-500/10 hover:bg-emerald-500/15 border-emerald-500/30 text-emerald-700 dark:text-emerald-300"
+            ? "bg-success/10 hover:bg-success/15 border-success/30 text-success"
             : "bg-muted/80 hover:bg-muted border-border/50"
         )}
       >
@@ -62,12 +62,12 @@ export function BranchChip({ branches, onOpenBranch }: BranchChipProps) {
             "transition-all duration-200 cursor-pointer",
             "border animate-chip-in",
             mergedCount > 0
-              ? "bg-emerald-500/10 hover:bg-emerald-500/15 border-emerald-500/30"
+              ? "bg-success/10 hover:bg-success/15 border-success/30"
               : "bg-muted/80 hover:bg-muted border-border/50"
           )}
         >
           {mergedCount > 0 ? (
-            <GitMerge className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+            <GitMerge className="h-3 w-3 text-success" />
           ) : (
             <GitBranch className="h-3 w-3 text-muted-foreground" />
           )}
@@ -89,7 +89,7 @@ export function BranchChip({ branches, onOpenBranch }: BranchChipProps) {
             className="flex items-center gap-2 cursor-pointer"
           >
             {branch.mergedIntoMain ? (
-              <GitMerge className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+              <GitMerge className="h-3.5 w-3.5 text-success shrink-0" />
             ) : (
               <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
             )}
@@ -113,8 +113,8 @@ function ModeIndicator({ mode }: { mode: "fast" | "deep" }) {
       className={cn(
         "inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px]",
         mode === "fast"
-          ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
-          : "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+          ? "bg-warning/15 text-warning"
+          : "bg-muted text-muted-foreground"
       )}
     >
       {mode === "fast" ? (
@@ -129,7 +129,7 @@ function ModeIndicator({ mode }: { mode: "fast" | "deep" }) {
 // Merged indicator
 function MergedIndicator() {
   return (
-    <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
+    <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] bg-success/20 text-success">
       <Check className="h-2.5 w-2.5" />
     </span>
   )

--- a/components/chat/branch-overlay.tsx
+++ b/components/chat/branch-overlay.tsx
@@ -354,7 +354,7 @@ export function BranchOverlay({
             </button>
           </div>
           {branch.mergedIntoMain && (
-            <span className="text-[10px] bg-green-500/10 text-green-600 dark:text-green-400 px-1.5 py-0.5 rounded-full font-medium">
+            <span className="text-[10px] uppercase tracking-[0.08em] bg-success/15 text-success px-1.5 py-0.5 rounded-full font-medium">
               merged
             </span>
           )}

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -50,10 +50,10 @@ export function ChatMessageBubble({
     const { branchTitle } = message.contextMeta
 
     return (
-      <div className="flex w-full justify-center animate-chip-in">
-        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20">
-          <GitMerge className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
-          <span className="text-xs text-emerald-700 dark:text-emerald-300">
+      <div className="flex w-full justify-start animate-chip-in">
+        <div className="inline-flex items-center gap-2 rounded-md border-l-2 border-l-thread bg-success/10 px-3 py-1.5">
+          <GitMerge className="h-3.5 w-3.5 shrink-0 text-success" />
+          <span className="text-xs font-medium text-success">
             Branch &ldquo;{branchTitle}&rdquo; context added
           </span>
         </div>
@@ -73,8 +73,8 @@ export function ChatMessageBubble({
           className={cn(
             "relative max-w-[80%] rounded-2xl px-4 py-2.5",
             isUser
-              ? "bg-primary text-primary-foreground rounded-br-md"
-              : "bg-muted text-foreground rounded-bl-md"
+              ? "bg-accent-soft text-foreground rounded-br-md"
+              : "bg-card text-foreground rounded-bl-md border border-border/40 shadow-sm"
           )}
         >
           {isUser ? (
@@ -104,7 +104,7 @@ export function ChatMessageBubble({
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                    className="h-7 w-7 text-muted-foreground hover:text-primary"
                     onClick={handleBranch}
                   >
                     <GitBranch className="h-3.5 w-3.5" />

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -53,7 +53,7 @@ export function Composer({
   return (
     <div
       className={cn(
-        "flex items-end gap-2 p-4 border-t border-border bg-card/50",
+        "flex items-end gap-2 p-4 border-t border-border/40 bg-card/60",
         className
       )}
     >

--- a/components/chat/file-attachment.tsx
+++ b/components/chat/file-attachment.tsx
@@ -24,14 +24,14 @@ export function FileAttachmentChip({
     <div
       className={cn(
         "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg",
-        "bg-primary/10 border border-primary/20 text-sm",
+        "bg-secondary border border-border/50 text-sm",
         className
       )}
     >
       {isProcessing ? (
-        <Loader2 className="h-3.5 w-3.5 text-primary animate-spin" />
+        <Loader2 className="h-3.5 w-3.5 text-muted-foreground animate-spin" />
       ) : (
-        <FileText className="h-3.5 w-3.5 text-primary" />
+        <FileText className="h-3.5 w-3.5 text-muted-foreground" />
       )}
       <span className="text-xs font-medium truncate max-w-[180px]">
         {filename}
@@ -43,7 +43,7 @@ export function FileAttachmentChip({
         <Button
           variant="ghost"
           size="icon"
-          className="h-4 w-4 p-0 hover:bg-primary/20 rounded-full ml-0.5"
+          className="h-4 w-4 p-0 hover:bg-accent rounded-full ml-0.5"
           onClick={onRemove}
         >
           <X className="h-3 w-3" />

--- a/components/chat/typing-indicator.tsx
+++ b/components/chat/typing-indicator.tsx
@@ -14,7 +14,7 @@ export function TypingIndicator({ className }: TypingIndicatorProps) {
         className
       )}
     >
-      <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-3">
+      <div className="bg-card border border-border/40 shadow-sm rounded-2xl rounded-bl-md px-4 py-3">
         <div className="flex items-center gap-1">
           <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-typing-dot" />
           <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-typing-dot animation-delay-150" />

--- a/components/chat/unified-demo-panels.tsx
+++ b/components/chat/unified-demo-panels.tsx
@@ -1,8 +1,18 @@
 "use client"
 
-import { FileAudio, Loader2, MessageSquare, Plus, Sparkles, Zap } from "lucide-react"
+import {
+  Code,
+  Loader2,
+  MessageSquare,
+  Paperclip,
+  Plus,
+  Search,
+  Sparkles,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { APP_BADGE, APP_NAME, APP_TAGLINE } from "@/lib/branding"
+import { cn } from "@/lib/utils"
 import type { StoredChatThreadMeta } from "@/lib/store/types"
 
 function formatRelativeTime(timestamp: number): string {
@@ -35,9 +45,9 @@ export function UnifiedSidebar({
   onSelectThread: (threadId: string) => void
 }) {
   return (
-    <div className="w-64 border-r border-border flex flex-col bg-muted/30">
-      <div className="p-3 border-b border-border">
-        <Button onClick={onReset} className="w-full gap-2" variant="outline">
+    <div className="w-64 border-r border-border/40 flex flex-col bg-surface-sunken">
+      <div className="p-3">
+        <Button onClick={onReset} className="w-full gap-2" variant="secondary">
           <Plus className="h-4 w-4" />
           New Chat
         </Button>
@@ -59,17 +69,24 @@ export function UnifiedSidebar({
                 <button
                   key={thread.id}
                   onClick={() => onSelectThread(thread.id)}
-                  className={`w-full text-left p-2.5 rounded-lg transition-colors hover:bg-accent/50 ${
-                    isActive ? "bg-accent" : ""
-                  }`}
+                  className={cn(
+                    "w-full text-left p-2.5 rounded-lg transition-colors",
+                    "border-l-2 border-l-transparent hover:bg-accent/60",
+                    isActive && "bg-accent-soft border-l-thread"
+                  )}
                 >
                   <div className="flex items-start gap-2">
-                    <MessageSquare className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                    <MessageSquare
+                      className={cn(
+                        "h-4 w-4 mt-0.5 shrink-0",
+                        isActive ? "text-primary" : "text-muted-foreground"
+                      )}
+                    />
                     <div className="flex-1 min-w-0">
                       <div className="text-sm font-medium truncate">
                         {thread.title || "New Chat"}
                       </div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="mt-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
                         {formatRelativeTime(thread.updatedAt)}
                       </div>
                     </div>
@@ -84,45 +101,110 @@ export function UnifiedSidebar({
   )
 }
 
-export function UnifiedEmptyState() {
+const EXAMPLE_PROMPTS: {
+  prompt: string
+  tag: string
+  icon: typeof MessageSquare
+}[] = [
+  {
+    prompt: "Plan a 3-day Kyoto trip focused on food",
+    tag: "Chat",
+    icon: MessageSquare,
+  },
+  {
+    prompt: "@codex add a dark-mode toggle to the settings page",
+    tag: "Task",
+    icon: Code,
+  },
+  {
+    prompt: "@assistant find unfinished work from this week",
+    tag: "Assistant",
+    icon: Sparkles,
+  },
+  {
+    prompt: "/find that chat about the Kyoto trip",
+    tag: "Find",
+    icon: Search,
+  },
+]
+
+const FEATURE_LEGEND = [
+  "Branch",
+  "Merge",
+  "Find",
+  "Codex",
+  "Assistant",
+  "Read aloud",
+]
+
+export function UnifiedEmptyState({
+  onSelectPrompt,
+}: {
+  onSelectPrompt?: (prompt: string) => void
+}) {
   return (
-    <div className="flex flex-col items-center justify-center h-full text-center p-8">
-      <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-        <Zap className="h-8 w-8 text-primary" />
-      </div>
-      <h3 className="text-lg font-medium mb-2">Unified Chat</h3>
-      <p className="text-sm text-muted-foreground max-w-sm mb-4">
-        All features in one place. Chat, branch, run Codex tasks, or find past
-        conversations.
-      </p>
-      <div className="text-xs text-muted-foreground/70 max-w-sm p-3 bg-muted rounded-lg space-y-2">
-        <p>
-          <strong>Features:</strong>
+    <div className="flex h-full flex-col items-center justify-center px-6 py-10">
+      <div className="w-full max-w-xl">
+        {/* Wordmark — the front door */}
+        <div className="flex items-baseline gap-2.5">
+          <h1 className="font-display text-4xl font-medium text-foreground">
+            {APP_NAME}
+          </h1>
+          <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
+            {APP_BADGE}
+          </span>
+        </div>
+        <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">
+          {APP_TAGLINE}
         </p>
-        <p>
-          <code className="bg-background px-1 rounded">@assistant</code> &mdash;
-          Work across chats and recover unfinished work
+
+        {/* Try one of these */}
+        <p className="mt-8 mb-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+          Try one of these
         </p>
-        <p>
-          <code className="bg-background px-1 rounded">@codex</code> &mdash;
-          Generate code with task cards
-        </p>
-        <p>
-          <code className="bg-background px-1 rounded">/find</code> &mdash;
-          Search past conversations
-        </p>
-        <p>
-          <span className="inline-flex items-center gap-1">
-            <Sparkles className="h-3 w-3" /> Branch
-          </span>{" "}
-          &mdash; Click branch on any assistant message
-        </p>
-        <p>
-          <span className="inline-flex items-center gap-1">
-            <FileAudio className="h-3 w-3" /> Doc Read
-          </span>{" "}
-          &mdash; Attach a PDF/DOCX and ask to read it aloud
-        </p>
+        <div className="grid gap-2">
+          {EXAMPLE_PROMPTS.map(({ prompt, tag, icon: Icon }) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => onSelectPrompt?.(prompt)}
+              className={cn(
+                "group flex w-full items-center gap-3 rounded-xl px-3.5 py-3 text-left",
+                "border border-border/50 bg-card transition-colors",
+                "hover:border-thread/40 hover:bg-accent-soft/40",
+                "focus:outline-none focus:ring-2 focus:ring-ring/40"
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+              <span className="flex-1 text-sm text-foreground">{prompt}</span>
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                {tag}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Doc-read hint (not a seedable prompt — needs a file) */}
+        <div className="mt-2 flex items-center gap-3 rounded-xl px-3.5 py-3 text-sm text-muted-foreground">
+          <Paperclip className="h-4 w-4 shrink-0 text-muted-foreground/70" />
+          <span>
+            Attach a PDF and say{" "}
+            <span className="text-foreground">&ldquo;read this to me&rdquo;</span>{" "}
+            for a narrated document.
+          </span>
+        </div>
+
+        {/* Feature legend — quiet tracked labels, not an info box */}
+        <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-1.5">
+          {FEATURE_LEGEND.map((label) => (
+            <span
+              key={label}
+              className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/50"
+            >
+              {label}
+            </span>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/components/codex/task-card.tsx
+++ b/components/codex/task-card.tsx
@@ -117,31 +117,31 @@ export function TaskCard({
   if (!isExpanded) {
     return (
       <div
-        className="flex items-center gap-3 px-4 py-3 bg-card border border-border dark:border-muted-foreground/25 rounded-xl cursor-pointer hover:bg-muted/50 transition-colors shadow-sm dark:shadow-md dark:shadow-black/20"
+        className="flex items-center gap-3 px-4 py-3 bg-card border border-border border-l-2 border-l-thread rounded-xl cursor-pointer hover:bg-muted/40 transition-colors shadow-[0_1px_2px_rgba(0,0,0,0.03)] dark:shadow-md dark:shadow-black/20"
         onClick={() => setIsExpanded(true)}
       >
         <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
         <div className="flex items-center gap-2 flex-1 min-w-0">
           {isRunning && (
-            <Loader2 className="h-4 w-4 animate-spin text-blue-500 shrink-0" />
+            <Loader2 className="h-4 w-4 animate-spin text-primary shrink-0" />
           )}
           {task.status === "draft_ready" && (
-            <FileCode className="h-4 w-4 text-amber-500 shrink-0" />
+            <FileCode className="h-4 w-4 text-warning shrink-0" />
           )}
           {task.status === "applied" && (
-            <Check className="h-4 w-4 text-green-500 shrink-0" />
+            <Check className="h-4 w-4 text-success shrink-0" />
           )}
           {task.status === "pr_created" && (
-            <GitPullRequest className="h-4 w-4 text-purple-500 shrink-0" />
+            <GitPullRequest className="h-4 w-4 text-primary shrink-0" />
           )}
-          {hasError && <AlertCircle className="h-4 w-4 text-red-500 shrink-0" />}
+          {hasError && <AlertCircle className="h-4 w-4 text-destructive shrink-0" />}
           <span className="text-sm font-medium truncate">
             Codex task • {task.title || "Processing..."}
           </span>
         </div>
         <span
           className={cn(
-            "text-[10px] px-2 py-0.5 rounded-full shrink-0",
+            "text-[10px] uppercase tracking-[0.08em] font-medium px-2 py-0.5 rounded-full shrink-0",
             TASK_STATUS_COLORS[task.status]
           )}
         >
@@ -156,9 +156,9 @@ export function TaskCard({
   // =============================================================================
 
   return (
-    <div className="bg-card border border-border dark:border-muted-foreground/25 rounded-xl overflow-hidden shadow-sm dark:shadow-md dark:shadow-black/20">
+    <div className="bg-card border border-border border-l-2 border-l-thread rounded-xl overflow-hidden shadow-[0_2px_16px_rgba(0,0,0,0.04)] dark:shadow-md dark:shadow-black/20">
       {/* Sticky Header */}
-      <div className="sticky top-0 z-10 bg-card border-b border-border dark:border-muted-foreground/20">
+      <div className="sticky top-0 z-10 bg-card border-b border-border/60">
         {/* Title row */}
         <div
           className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors"
@@ -167,7 +167,7 @@ export function TaskCard({
           <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
           <div className="flex items-center gap-2 flex-1 min-w-0">
             {isRunning && (
-              <Loader2 className="h-4 w-4 animate-spin text-blue-500 shrink-0" />
+              <Loader2 className="h-4 w-4 animate-spin text-primary shrink-0" />
             )}
             <span className="text-sm font-medium truncate">
               {task.title || "Processing..."}
@@ -175,7 +175,7 @@ export function TaskCard({
           </div>
           <span
             className={cn(
-              "text-[10px] px-2 py-0.5 rounded-full shrink-0",
+              "text-[10px] uppercase tracking-[0.08em] font-medium px-2 py-0.5 rounded-full shrink-0",
               TASK_STATUS_COLORS[task.status]
             )}
           >
@@ -226,7 +226,7 @@ export function TaskCard({
                   href={task.prUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1 text-xs text-purple-600 dark:text-purple-400 hover:underline px-2"
+                  className="flex items-center gap-1 text-xs text-primary hover:underline px-2"
                 >
                   <ExternalLink className="h-3 w-3" />
                   View PR
@@ -517,16 +517,16 @@ function ProgressView({
         <div className="flex items-center gap-3">
           <span
             className={cn(
-              "text-xs font-medium px-2.5 py-1 rounded-full transition-all duration-300",
+              "text-[10px] uppercase tracking-[0.08em] font-medium px-2.5 py-1 rounded-full transition-all duration-300",
               currentStatus === "Queued" && "bg-muted text-muted-foreground",
-              currentStatus === "Planning" && "bg-blue-500/20 text-blue-600 dark:text-blue-400",
-              currentStatus === "Generating" && "bg-purple-500/20 text-purple-600 dark:text-purple-400"
+              currentStatus === "Planning" && "bg-accent-soft text-primary",
+              currentStatus === "Generating" && "bg-accent-soft text-primary"
             )}
           >
             {currentStatus}
           </span>
           {isRefreshing && (
-            <div className="h-2 w-2 bg-blue-500 rounded-full animate-pulse" />
+            <div className="h-2 w-2 bg-primary rounded-full animate-pulse" />
           )}
         </div>
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -540,7 +540,7 @@ function ProgressView({
         {/* Spinner and current action */}
         <div className="text-center space-y-3">
           <div className="relative inline-block">
-            <Loader2 className="h-10 w-10 animate-spin text-blue-500" />
+            <Loader2 className="h-10 w-10 animate-spin text-primary" />
           </div>
           <p className="text-sm font-medium text-foreground">{currentText}</p>
         </div>
@@ -549,7 +549,7 @@ function ProgressView({
         <div className="space-y-2">
           <div className="h-1.5 bg-muted rounded-full overflow-hidden">
             <div
-              className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-blue-400 rounded-full transition-all duration-150 ease-out"
+              className="h-full bg-primary rounded-full transition-all duration-150 ease-out"
               style={{ width: `${Math.round(progress)}%` }}
             />
           </div>
@@ -562,12 +562,12 @@ function ProgressView({
 
       {/* Animated log output - fixed at bottom */}
       <div className="mt-auto pt-4">
-        <ScrollArea className="h-[100px] bg-muted/30 rounded-lg border border-border/50">
+        <ScrollArea className="h-[100px] bg-surface-sunken rounded-lg border border-border/50">
           <div className="p-3 space-y-1.5 font-mono text-[11px]">
             {/* Real logs if any */}
             {task.logs.length > 0 && task.logs.slice(-2).map((log, idx) => (
               <div key={`real-${idx}`} className="text-foreground/70 flex items-start gap-2">
-                <Check className="h-3 w-3 text-green-500 shrink-0 mt-0.5" />
+                <Check className="h-3 w-3 text-success shrink-0 mt-0.5" />
                 <span>{log}</span>
               </div>
             ))}
@@ -578,7 +578,7 @@ function ProgressView({
                 className="text-muted-foreground flex items-start gap-2 transition-opacity duration-300"
                 style={{ opacity: log.opacity }}
               >
-                <span className="text-blue-400 shrink-0">→</span>
+                <span className="text-primary/70 shrink-0">→</span>
                 <span>{log.text}</span>
               </div>
             ))}
@@ -602,15 +602,15 @@ function ErrorView({ task }: { task: CodexTask }) {
   return (
     <div className="h-full flex items-center justify-center p-8">
       <div className="text-center space-y-4 max-w-md">
-        <div className="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center mx-auto">
-          <AlertCircle className="h-6 w-6 text-red-500" />
+        <div className="w-12 h-12 rounded-full bg-destructive/10 flex items-center justify-center mx-auto">
+          <AlertCircle className="h-6 w-6 text-destructive" />
         </div>
         <div>
           <p className="text-sm font-medium text-foreground mb-2">Task Failed</p>
-          <p className="text-sm text-red-600 dark:text-red-400">{task.error}</p>
+          <p className="text-sm text-destructive">{task.error}</p>
         </div>
         {task.logs.length > 0 && (
-          <div className="bg-muted/50 rounded-lg p-3 text-left max-h-[150px] overflow-auto">
+          <div className="bg-surface-sunken rounded-lg p-3 text-left max-h-[150px] overflow-auto">
             <div className="space-y-1 font-mono text-[11px]">
               {task.logs.map((log, idx) => (
                 <div key={idx} className="text-muted-foreground">
@@ -656,16 +656,16 @@ function FileListItem({
       <span className="text-xs font-mono truncate flex-1">{change.path}</span>
       <span
         className={cn(
-          "text-[9px] px-1 py-0.5 rounded shrink-0",
+          "text-[9px] uppercase tracking-[0.08em] font-medium px-1 py-0.5 rounded shrink-0",
           isNew
-            ? "bg-green-500/20 text-green-600 dark:text-green-400"
-            : "bg-amber-500/20 text-amber-600 dark:text-amber-400"
+            ? "bg-success/15 text-success"
+            : "bg-warning/15 text-warning-foreground dark:text-warning"
         )}
       >
         {isNew ? "NEW" : "MOD"}
       </span>
       {isApplied && (
-        <Check className="h-3 w-3 text-green-500 shrink-0" />
+        <Check className="h-3 w-3 text-success shrink-0" />
       )}
     </button>
   )
@@ -690,36 +690,36 @@ function DiffPreview({
   return (
     <div className="flex flex-col h-full">
       {/* Diff header */}
-      <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 border-b border-border">
+      <div className="flex items-center gap-2 px-4 py-2 bg-surface-sunken border-b border-border/60">
         <FileCode className="h-3.5 w-3.5 text-muted-foreground" />
         <span className="text-xs font-mono flex-1">{change.path}</span>
         <span
           className={cn(
-            "text-[10px] px-1.5 py-0.5 rounded",
+            "text-[10px] uppercase tracking-[0.08em] font-medium px-1.5 py-0.5 rounded",
             isNew
-              ? "bg-green-500/20 text-green-600 dark:text-green-400"
-              : "bg-amber-500/20 text-amber-600 dark:text-amber-400"
+              ? "bg-success/15 text-success"
+              : "bg-warning/15 text-warning-foreground dark:text-warning"
           )}
         >
           {isNew ? "NEW FILE" : "MODIFIED"}
         </span>
         {isApplied && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/20 text-green-600 dark:text-green-400">
+          <span className="text-[10px] uppercase tracking-[0.08em] font-medium px-1.5 py-0.5 rounded bg-success/15 text-success">
             APPLIED
           </span>
         )}
       </div>
 
       {/* Diff content */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 bg-surface-sunken">
         <pre className="p-4 text-xs font-mono leading-relaxed">
           {diffLines.map((line, idx) => (
             <div
               key={idx}
               className={cn(
                 "whitespace-pre",
-                line.type === "add" && "bg-green-500/10 text-green-700 dark:text-green-300",
-                line.type === "remove" && "bg-red-500/10 text-red-700 dark:text-red-300",
+                line.type === "add" && "bg-success/10 text-success",
+                line.type === "remove" && "bg-destructive/10 text-destructive",
                 line.type === "header" && "text-muted-foreground font-semibold"
               )}
             >

--- a/components/history/finder-option-card.tsx
+++ b/components/history/finder-option-card.tsx
@@ -56,14 +56,14 @@ function getConfidenceDisplay(confidence: number): {
   if (confidence >= 0.85) {
     return {
       label: "High match",
-      className: "text-green-600 dark:text-green-400",
+      className: "text-success",
       icon: <CheckCircle2 className="h-3 w-3" />,
     }
   }
   if (confidence >= 0.6) {
     return {
       label: "Good match",
-      className: "text-blue-600 dark:text-blue-400",
+      className: "text-foreground/80",
       icon: <Circle className="h-3 w-3" />,
     }
   }
@@ -108,10 +108,10 @@ export function FinderOptionCard({
       onClick={onClick}
       disabled={disabled || isOpening}
       className={cn(
-        "w-full text-left p-4 rounded-xl border transition-all duration-200",
-        "bg-card hover:bg-accent/50 border-border",
-        "focus:outline-none focus:ring-2 focus:ring-primary/20",
-        isOpening && "bg-primary/5 border-primary/30",
+        "group w-full text-left p-4 rounded-lg transition-all duration-200",
+        "border-l-2 border-l-thread bg-card hover:bg-accent-soft/40",
+        "focus:outline-none focus:ring-2 focus:ring-ring/40",
+        isOpening && "bg-accent-soft/60",
         disabled && "opacity-50 cursor-not-allowed"
       )}
     >
@@ -169,8 +169,8 @@ export function FinderOptionCard({
           className={cn(
             "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors",
             isOpening
-              ? "bg-primary/10 text-primary"
-              : "bg-primary text-primary-foreground hover:bg-primary/90"
+              ? "bg-accent-soft text-primary"
+              : "bg-secondary text-secondary-foreground group-hover:bg-accent-soft group-hover:text-primary"
           )}
         >
           {isOpening ? (

--- a/components/history/finder-view.tsx
+++ b/components/history/finder-view.tsx
@@ -586,12 +586,12 @@ export function FinderView({
                       message.role === "user"
                         ? "bg-primary text-primary-foreground rounded-br-md"
                         : message.role === "context"
-                        ? "bg-amber-500/10 text-foreground border border-amber-500/20 rounded-bl-md"
+                        ? "bg-warning/10 text-foreground border border-warning/20 rounded-bl-md"
                         : "bg-card text-card-foreground border border-border rounded-bl-md"
                     )}
                   >
                     {message.role === "context" && (
-                      <div className="text-[10px] text-amber-600 dark:text-amber-400 font-medium mb-1">
+                      <div className="text-[10px] uppercase tracking-[0.08em] text-warning-foreground dark:text-warning font-medium mb-1">
                         CONTEXT
                       </div>
                     )}

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
+import { APP_BADGE, APP_NAME } from "@/lib/branding"
 
 const demoItems = [
   {
@@ -141,14 +142,17 @@ function StorageIndicator() {
     }
   }
 
-  const getColorClass = () => {
+  // Signal color drawn from the same-room token set (success sage / warning
+  // flax / destructive brick), carried only on the small icon so the pill
+  // itself stays quiet.
+  const getIconColorClass = () => {
     switch (storageInfo.type) {
       case "kv":
-        return "text-green-600 dark:text-green-400"
+        return "text-[hsl(var(--success))]"
       case "memory":
-        return "text-amber-600 dark:text-amber-400"
+        return "text-[hsl(var(--warning))]"
       case "error":
-        return "text-red-600 dark:text-red-400"
+        return "text-[hsl(var(--destructive))]"
     }
   }
 
@@ -156,13 +160,8 @@ function StorageIndicator() {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div
-            className={cn(
-              "flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-md border border-border/50 bg-muted/50",
-              getColorClass()
-            )}
-          >
-            {getIcon()}
+          <div className="flex items-center gap-1.5 rounded-md border border-border/60 bg-secondary/40 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            <span className={getIconColorClass()}>{getIcon()}</span>
             <span>{getLabel()}</span>
           </div>
         </TooltipTrigger>
@@ -193,13 +192,18 @@ export function Nav() {
   const currentDemo = demoItems.find((item) => pathname === item.href)
 
   return (
-    <nav className="flex items-center justify-between px-6 py-4 border-b border-border/50">
+    <nav className="flex items-center justify-between border-b border-border/40 px-6 py-4">
       <div className="flex items-center gap-1">
         <Link
           href="/"
-          className="text-lg font-semibold tracking-tight mr-6 hover:text-muted-foreground transition-colors"
+          className="mr-6 flex items-baseline gap-2 transition-colors hover:text-foreground"
         >
-          LLM Chat Demos
+          <span className="font-display text-xl font-medium text-foreground/90">
+            {APP_NAME}
+          </span>
+          <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            {APP_BADGE}
+          </span>
         </Link>
         <div className="flex items-center gap-1">
           <DropdownMenu>

--- a/components/ui/markdown-content.tsx
+++ b/components/ui/markdown-content.tsx
@@ -64,7 +64,7 @@ export function MarkdownContent({ content, className, isUser = false }: Markdown
                     "px-1 py-0.5 rounded text-[0.8em] font-mono",
                     isUser
                       ? "bg-primary-foreground/20 text-primary-foreground"
-                      : "bg-background/60 text-foreground border border-border/50"
+                      : "bg-surface-sunken text-foreground border border-border/40"
                   )}
                   {...rest}
                 >
@@ -87,7 +87,7 @@ export function MarkdownContent({ content, className, isUser = false }: Markdown
                   "my-2 p-3 rounded-lg text-xs font-mono overflow-x-auto",
                   isUser
                     ? "bg-primary-foreground/15 text-primary-foreground"
-                    : "bg-background/70 text-foreground border border-border/50"
+                    : "bg-surface-sunken text-foreground border border-border/40"
                 )}
               >
                 {children}

--- a/components/ui/storage-warning-banner.tsx
+++ b/components/ui/storage-warning-banner.tsx
@@ -64,19 +64,19 @@ export function StorageWarningBanner({ className }: StorageWarningBannerProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-3 py-2 text-sm bg-amber-500/10 border border-amber-500/20 rounded-lg",
+        "flex items-center gap-2 px-3 py-2 text-sm bg-warning/10 border border-warning/20 rounded-lg",
         className
       )}
     >
-      <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" />
-      <span className="flex-1 text-amber-700 dark:text-amber-300 text-xs">
+      <AlertTriangle className="h-4 w-4 text-warning shrink-0" />
+      <span className="flex-1 text-muted-foreground text-xs">
         {status.warning ||
           "Storage is running in demo-local mode. History may reset on refresh."}
         <a
           href="https://vercel.com/docs/storage/vercel-redis"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 ml-1 underline underline-offset-2 hover:text-amber-600 dark:hover:text-amber-200"
+          className="inline-flex items-center gap-1 ml-1 text-foreground/80 underline underline-offset-2 hover:text-foreground"
         >
           Configure Redis
           <ExternalLink className="h-3 w-3" />
@@ -84,7 +84,7 @@ export function StorageWarningBanner({ className }: StorageWarningBannerProps) {
       </span>
       <button
         onClick={() => setDismissed(true)}
-        className="p-0.5 rounded hover:bg-amber-500/20 text-amber-600 dark:text-amber-400"
+        className="p-0.5 rounded hover:bg-warning/15 text-muted-foreground hover:text-foreground"
         aria-label="Dismiss warning"
       >
         <X className="h-3.5 w-3.5" />

--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for product naming.
+ *
+ * Public name: "Chat, rewoven" — a working concept for the next iteration
+ * of the ChatGPT-class interface. The internal design identity is
+ * "Interlace" (weaving as inherited principle), which the name inherits
+ * through "rewoven". The demo marker is rendered separately so the wordmark
+ * stays clean.
+ */
+export const APP_NAME = "Chat, rewoven"
+
+/** Small qualifier rendered next to the wordmark and in titles */
+export const APP_BADGE = "demo"
+
+export const APP_TAGLINE =
+  "A working concept for the next iteration of the ChatGPT interface — branching, history, code tasks, documents, and an assistant, woven into one chat."

--- a/lib/codex/types.ts
+++ b/lib/codex/types.ts
@@ -104,16 +104,18 @@ export const TASK_STATUS_LABELS: Record<CodexTaskStatus, string> = {
 }
 
 /**
- * Status colors for UI
+ * Status colors for UI — Interlace same-room signal tokens (quiet tinted washes).
+ * ready/pending = flax warning, applied/done = sage success, failed = brick
+ * destructive, running & PR = the dyed-thread accent family.
  */
 export const TASK_STATUS_COLORS: Record<CodexTaskStatus, string> = {
   queued: "bg-muted text-muted-foreground",
-  running: "bg-blue-500/20 text-blue-600 dark:text-blue-400",
-  draft_ready: "bg-amber-500/20 text-amber-600 dark:text-amber-400",
-  applied: "bg-green-500/20 text-green-600 dark:text-green-400",
-  pr_created: "bg-purple-500/20 text-purple-600 dark:text-purple-400",
-  done: "bg-green-500/20 text-green-600 dark:text-green-400",
-  failed: "bg-red-500/20 text-red-600 dark:text-red-400",
+  running: "bg-accent-soft text-primary",
+  draft_ready: "bg-warning/15 text-warning-foreground dark:text-warning",
+  applied: "bg-success/15 text-success",
+  pr_created: "bg-accent-soft text-primary",
+  done: "bg-success/15 text-success",
+  failed: "bg-destructive/15 text-destructive",
 }
 
 /**


### PR DESCRIPTION
## What this is

The identity-driven design pass. Internal design concept: **Interlace** — weaving as an inherited principle (the product's own vocabulary is thread/branch/merge), never as decoration. Public name: **Chat, rewoven (demo)**.

## Changes

- **Token system:** warm-linen light mode / warm-charcoal dark mode replacing stock shadcn zinc; a single desaturated terracotta accent (the "dyed thread") reserved for context-event moments; same-room signal tokens (sage success, flax warning, brick error)
- **Typography:** Fraunces display + Public Sans UI + IBM Plex Mono via next/font
- **Shell:** de-framed to a full-bleed single surface; sidebar becomes a tonal region; conversation column centered at reading width
- **Chat surface:** quiet warm user bubbles (no more near-black ChatGPT clone bubble), card-tone assistant bubbles, weft-moment treatment (2px thread edge) for merged context, finder results, audio players, and task cards
- **Empty state:** display-face wordmark + tagline + four clickable example prompts that seed the composer toward the demo's core moments
- **Feature surfaces:** codex/assistant task cards, branch overlay, storage notice, standalone pages all moved onto the token system with tracked-uppercase status labels
- **Branding:** `lib/branding.ts` single source; GitHub metadata + `chat-rewoven.vercel.app` domain live

Verified with visual review in both light and dark (empty state + seeded conversation). Class-level changes only; behavior untouched except the empty-state prompt insertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)